### PR TITLE
use a "FutureLocal" context to enable the usage of ClumpSources as singletons

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -6,6 +6,8 @@ import com.twitter.util.Try
 
 trait Clump[T] {
 
+  private val forceContextInit = ClumpContext()
+
   def map[U](f: T => U) = flatMap(f.andThen(Clump.value(_)))
 
   def flatMap[U](f: T => Clump[U]): Clump[U] = new ClumpFlatMap(this, f)
@@ -70,8 +72,8 @@ class ClumpCollect[T](list: List[Clump[T]]) extends Clump[List[T]] {
       .map(Some(_))
 }
 
-class ClumpFetch[T, U](input: T, source: ClumpSource[T, U]) extends Clump[U] {
-  lazy val result = source.run(input)
+class ClumpFetch[T, U](input: T, fetcher: ClumpFetcher[T, U]) extends Clump[U] {
+  lazy val result = fetcher.run(input)
 }
 
 class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) extends Clump[U] {

--- a/src/main/scala/clump/ClumpContext.scala
+++ b/src/main/scala/clump/ClumpContext.scala
@@ -1,0 +1,29 @@
+package clump
+
+import com.twitter.util.Local
+import scala.collection.mutable.HashMap
+import scala.collection.mutable.SynchronizedMap
+
+class ClumpContext {
+
+  private val fetchers = new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
+
+  def fetcherFor[T, U](source: ClumpSource[T, U]) =
+    synchronized {
+      fetchers
+        .getOrElseUpdate(source, new ClumpFetcher(source))
+        .asInstanceOf[ClumpFetcher[T, U]]
+    }
+}
+
+object ClumpContext {
+
+  private val local = new Local[ClumpContext]
+
+  def apply() =
+    local().getOrElse {
+      val context = new ClumpContext
+      local.set(Some(context))
+      context
+    }
+}

--- a/src/main/scala/clump/ClumpFetcher.scala
+++ b/src/main/scala/clump/ClumpFetcher.scala
@@ -1,0 +1,45 @@
+package clump
+
+import com.twitter.util.Future
+
+class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
+
+  private var pending = Set[T]()
+  private var fetched = Map[T, Future[Option[U]]]()
+
+  def append(input: T) =
+    synchronized {
+      retryFailures(input)
+      pending += input
+    }
+
+  def run(input: T) =
+    fetched.getOrElse(input, flushAndGet(input))
+
+  private def flushAndGet(input: T): Future[Option[U]] =
+    flush.flatMap { _ => fetched(input) }
+
+  private def flush =
+    synchronized {
+      val toFetch = pending -- fetched.keys
+      val fetch = fetchInBatches(toFetch)
+      pending = Set()
+      fetch
+    }
+
+  private def fetchInBatches(toFetch: Set[T]) =
+    Future.collect {
+      toFetch.grouped(source.maxBatchSize).toList.map { batch =>
+        val results = source.fetch(batch.toList)
+        for (input <- batch)
+          fetched += input -> results.map(_.get(input))
+        results
+      }
+    }
+
+  private def retryFailures(input: T) =
+    fetched.get(input).map { result =>
+      if (result.poll.forall(_.isThrow))
+        fetched -= input
+    }
+}

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -2,50 +2,18 @@ package clump
 
 import com.twitter.util.Future
 
-class ClumpSource[T, U](fetch: List[T] => Future[Map[T, U]], maxBatchSize: Int) {
+class ClumpSource[T, U](val fetch: List[T] => Future[Map[T, U]], val maxBatchSize: Int) {
 
   def this(fetch: List[T] => Future[List[U]], keyFn: U => T, maxBatchSize: Int) = {
     this(fetch.andThen(_.map(_.map(v => (keyFn(v), v)).toMap)), maxBatchSize)
   }
 
-  private var pending = Set[T]()
-  private var fetched = Map[T, Future[Option[U]]]()
+  def get(inputs: List[T]): Clump[List[U]] =
+    Clump.collect(inputs.map(get))
 
   def get(input: T): Clump[U] = {
-    synchronized {
-      retryFailures(input)
-      pending += input
-    }
-    new ClumpFetch(input, this)
+    val fetcher = ClumpContext().fetcherFor(this)
+    fetcher.append(input)
+    new ClumpFetch(input, fetcher)
   }
-
-  def get(inputs: List[T]): Clump[List[U]] = Clump.collect(inputs.map(get))
-
-  private[clump] def run(input: T) = fetched.getOrElse(input, flushAndGet(input))
-
-  private def flushAndGet(input: T): Future[Option[U]] = flush.flatMap { _ => fetched(input) }
-
-  private def flush =
-    synchronized {
-      val toFetch = pending -- fetched.keys
-      val fetch = fetchInBatches(toFetch)
-      pending = Set()
-      fetch
-    }
-
-  private def fetchInBatches(toFetch: Set[T]) =
-    Future.collect {
-      toFetch.grouped(maxBatchSize).toList.map { batch =>
-        val results = fetch(batch.toList)
-        for (input <- batch)
-          fetched += input -> results.map(_.get(input))
-        results
-      }
-    }
-
-  private def retryFailures(input: T) =
-    fetched.get(input).map { result =>
-      if (result.poll.forall(_.isThrow))
-        fetched -= input
-    }
 }

--- a/src/test/scala/clump/ClumpFetcherSpec.scala
+++ b/src/test/scala/clump/ClumpFetcherSpec.scala
@@ -1,0 +1,69 @@
+package clump
+
+import org.specs2.mutable.Specification
+import org.specs2.mock.Mockito
+import org.specs2.specification.Scope
+import com.twitter.util.Future
+import org.mockito.Mockito._
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ClumpFetcherSpec extends Spec {
+
+  trait Context extends Scope {
+    trait TestRepository {
+      def fetch(inputs: List[Int]): Future[Map[Int, Int]]
+    }
+
+    val repo = smartMock[TestRepository]
+  }
+
+  "memoizes the results of previous fetches" in new Context {
+    val source = Clump.sourceFrom(repo.fetch)
+
+    when(repo.fetch(List(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
+    when(repo.fetch(List(3))).thenReturn(Future(Map(3 -> 30)))
+
+    val clump1 = Clump.traverse(List(1, 2))(source.get)
+
+    clumpResult(clump1) mustEqual Some(List(10, 20))
+
+    val clump2 = Clump.traverse(List(2, 3))(source.get)
+
+    clumpResult(clump2) mustEqual Some(List(20, 30))
+
+    verify(repo).fetch(List(1, 2))
+    verify(repo).fetch(List(3))
+    verifyNoMoreInteractions(repo)
+  }
+
+  "limits the batch size" in new Context {
+    val source = Clump.sourceFrom(repo.fetch, maxBatchSize = 2)
+
+    when(repo.fetch(List(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
+    when(repo.fetch(List(3))).thenReturn(Future(Map(3 -> 30)))
+
+    val clump = Clump.traverse(List(1, 2, 3))(source.get)
+
+    clumpResult(clump) mustEqual Some(List(10, 20, 30))
+
+    verify(repo).fetch(List(1, 2))
+    verify(repo).fetch(List(3))
+    verifyNoMoreInteractions(repo)
+  }
+
+  "retries failed fetches" in new Context {
+    val source = Clump.sourceFrom(repo.fetch)
+
+    when(repo.fetch(List(1)))
+      .thenReturn(Future.exception(new IllegalStateException))
+      .thenReturn(Future(Map(1 -> 10)))
+
+    clumpResult(source.get(1)) must throwA[IllegalStateException]
+    clumpResult(source.get(1)) mustEqual Some(10)
+
+    verify(repo, times(2)).fetch(List(1))
+    verifyNoMoreInteractions(repo)
+  }
+}

--- a/src/test/scala/clump/CumpContextSpec.scala
+++ b/src/test/scala/clump/CumpContextSpec.scala
@@ -1,0 +1,37 @@
+package clump
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import com.twitter.util.Future
+import com.twitter.util.Await
+
+@RunWith(classOf[JUnitRunner])
+class CumpContextSpec extends Spec {
+
+  "returns always the same fetcher for a source" in {
+    val context = new ClumpContext
+    val source = mock[ClumpSource[Int, Int]]
+    context.fetcherFor(source) mustEqual
+      context.fetcherFor(source)
+  }
+
+  "is stored using a local value" >> {
+
+    "that is propagated to downstream futures" in {
+      Await.result {
+        Future.value(ClumpContext()).map {
+          _ mustEqual ClumpContext()
+        }
+      }
+    }
+
+    "that is created for each new execution context" in {
+      def context =
+        Future.Unit.map { _ =>
+          ClumpContext()
+        }
+      Await.result(context) mustNotEqual
+        Await.result(context)
+    }
+  }
+}


### PR DESCRIPTION
The `ClumpContext` is basically an indirection that allows to remove the mutable state from the `ClumpSource`, so we can use it as a singleton. The context is maintained by a "FutureLocal", that is created for each new future composition chain.
