### PR TITLE
unwrap clump results with clump.get convenience method

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -20,7 +20,9 @@ trait Clump[T] {
 
   def withFilter(f: T => Boolean) = new ClumpFilter(this, f)
 
-  def run = Future.Unit.flatMap(_ => result)
+  def get: Future[T] = run.map(_.get)
+
+  def run: Future[Option[T]] = Future.Unit.flatMap(_ => result)
 
   protected def result: Future[Option[T]]
 }

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -26,10 +26,10 @@ class IntegrationSpec extends Spec {
         } yield (tweet, user)
       }
 
-    Await.result(enrichedTweets.run) ==== Some(List(
+    Await.result(enrichedTweets.get) ==== List(
       (Tweet("Tweet1", 10), User(10, "User10")),
       (Tweet("Tweet2", 20), User(20, "User20")),
-      (Tweet("Tweet3", 30), User(30, "User30"))))
+      (Tweet("Tweet3", 30), User(30, "User30")))
   }
 
   "it should be able to be used in complex nested fetches" in {
@@ -46,13 +46,13 @@ class IntegrationSpec extends Spec {
         } yield (timeline, enrichedLikes)
       }
 
-    Await.result(enrichedTimelines.run) ==== Some(List(
+    Await.result(enrichedTimelines.get) ==== List(
       (Timeline(1, List(10, 20)), List(
         (Like(10, List(100, 200), List(1000, 2000)), List(Track(100, "Track100"), Track(200, "Track200")), List(User(1000, "User1000"), User(2000, "User2000"))),
         (Like(20, List(200, 400), List(2000, 4000)), List(Track(200, "Track200"), Track(400, "Track400")), List(User(2000, "User2000"), User(4000, "User4000"))))),
       (Timeline(3, List(30, 60)), List(
         (Like(30, List(300, 600), List(3000, 6000)), List(Track(300, "Track300"), Track(600, "Track600")), List(User(3000, "User3000"), User(6000, "User6000"))),
-        (Like(60, List(600, 1200), List(6000, 12000)), List(Track(600, "Track600"), Track(1200, "Track1200")), List(User(6000, "User6000"), User(12000, "User12000")))))))
+        (Like(60, List(600, 1200), List(6000, 12000)), List(Track(600, "Track600"), Track(1200, "Track1200")), List(User(6000, "User6000"), User(12000, "User12000"))))))
   }
 
   "it should be usable with regular maps and flatMaps" in {
@@ -63,10 +63,10 @@ class IntegrationSpec extends Spec {
           users.get(tweet.userId).map(user => (tweet, user)))
       }
 
-    Await.result(enrichedTweets.run) ==== Some(List(
+    Await.result(enrichedTweets.get) ==== List(
       (Tweet("Tweet1", 10), User(10, "User10")),
       (Tweet("Tweet2", 20), User(20, "User20")),
-      (Tweet("Tweet3", 30), User(30, "User30"))))
+      (Tweet("Tweet3", 30), User(30, "User30")))
   }
 }
 


### PR DESCRIPTION
@fwbrasil interested in your opinions around naming conventions with `run` vs `get`. The get in this case was inspired by `option.get`. But scala seems inconsistent about what `get` means because for a map, a `get` returns an `Option` while apply is the strict one that may fail.
