### PR TITLE
WIP Implement ClumpSource.apply(input) to allow strict fail-if-not-found behaviour

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -75,8 +75,8 @@ class ClumpCollect[T](list: List[Clump[T]]) extends Clump[List[T]] {
       .map(Some(_))
 }
 
-class ClumpFetch[T, U](input: T, fetcher: ClumpFetcher[T, U]) extends Clump[U] {
-  lazy val result = fetcher.run(input)
+class ClumpFetch[T, U](input: T, fetcher: ClumpFetcher[T, U], strict: Boolean) extends Clump[U] {
+  lazy val result = fetcher.run(input, strict)
 }
 
 class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) extends Clump[U] {

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -14,6 +14,12 @@ class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize
   def get(input: T): Clump[U] = {
     val fetcher = ClumpContext().fetcherFor(this)
     fetcher.append(input)
-    new ClumpFetch(input, fetcher)
+    new ClumpFetch(input, fetcher, strict = false)
+  }
+
+  def apply(input: T): Clump[U] = {
+    val fetcher = ClumpContext().fetcherFor(this)
+    fetcher.append(input)
+    new ClumpFetch(input, fetcher, strict = true)
   }
 }


### PR DESCRIPTION
@fwbrasil there may be a more elegant way to implement this aside from passing a Boolean around. 

I thought it might be nice to get people the option to EXPECT keys to be found and fail-fast if they are not. Following the semantics from scala `Map`, `apply` is strict, `get` returns an `Option`

Possibly I should be adding unit-tests for these too, currently I only modified the integration spec. 

WDYT?
