### PR TITLE
Demo how partial responses don't work so well

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -27,6 +27,8 @@ trait Clump[+T] {
 
   def orElse[B >: T](default: => B): Clump[B] = new ClumpOrElse(this, default)
 
+  def optional: Clump[Option[T]] = new ClumpOptional(this)
+
   def apply: Future[T] = get.map(_.get)
 
   def get: Future[Option[T]] =
@@ -148,4 +150,10 @@ class ClumpOrElse[T](clump: Clump[T], default: => T) extends Clump[T] {
     case None => Some(default)
     case some => some
   }
+}
+
+class ClumpOptional[T](clump: Clump[T]) extends Clump[Option[T]] {
+  val upstream = List(clump)
+  val downstream = Future.value(List())
+  val result = clump.result.map(Some(_))
 }

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -22,6 +22,8 @@ class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize
 
   def apply(input: T): Clump[U] =
     get(input).orElse(throw new NoSuchElementException)
+
+  def optional(input: T): Clump[Option[U]] = get(input).optional
 }
 
 object ClumpSource {

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -178,5 +178,15 @@ class ClumpApiSpec extends Spec {
         case e: Throwable              => ko(s"expected NoSuchElementException but was $e")
       }
     }
+
+    "can be made optional (clump.optional) to avoid lossy joins" in {
+      val clump: Clump[String] = Clump.None
+      val optionalClump: Clump[Option[String]] = clump.optional
+      clumpResult(optionalClump) ==== Some(None)
+
+      val valueClump: Clump[String] = Clump.value("foo")
+      clumpResult(valueClump.join(clump)) ==== None
+      clumpResult(valueClump.join(optionalClump)) ==== Some("foo", None)
+    }
   }
 }

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -31,7 +31,7 @@ class ClumpSourceSpec extends Spec {
     verifyNoMoreInteractions(repo)
   }
 
-  "provides failfast and fallbacks when fetching" in new Context {
+  "provides failfast, fallbacks and optional when fetching" in new Context {
     val source = Clump.sourceFrom(repo.fetch)
 
     when(repo.fetch(Set(1))).thenReturn(Future(Map[Int, Int]()))
@@ -39,6 +39,7 @@ class ClumpSourceSpec extends Spec {
     clumpResult(source.get(1)) ==== None
     clumpResult(source.getOrElse(1, 2)) ==== Some(2)
     clumpResult(source(1)) must throwA[NoSuchElementException]
+    clumpResult(source.optional(1)) ==== Some(None)
   }
 
   "fetches multiple clumps" >> {


### PR DESCRIPTION
Hey @fwbrasil, this isn't something I want to commit, but just an example to show how I think partial responses don't work very well at the moment with the option-powered clumps. Currently there doesn't seem to be an easy way to allow "partial responses". For example, you get a tweet, then you want to get the user for the tweet. If the user cannot be found, currently you lose both the user AND the tweet. Ideally it would be better if you could make the User an option, as in the second half of the spec.

Let me know if you don't get what I mean
