### PR TITLE
Fine grained fetches

### DIFF
--- a/src/main/scala/clump/ClumpFetcher.scala
+++ b/src/main/scala/clump/ClumpFetcher.scala
@@ -13,7 +13,15 @@ class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
       pending += input
     }
 
-  def run(input: T) =
+  def apply(input: T): Future[U] =
+    get(input).map { option =>
+      if (option.isEmpty) throw new RuntimeException(s"Expected result for input: $input")
+      option.get
+    }
+
+  def getOrElse(input: T, default: U): Future[U] = get(input).map(_.getOrElse(default))
+
+  def get(input: T): Future[Option[U]] =
     fetched.getOrElse(input, flushAndGet(input))
 
   private def flushAndGet(input: T): Future[Option[U]] =

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -8,12 +8,25 @@ class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize
     this(fetch.andThen(_.map(_.map(v => (keyFn(v), v)).toMap)), maxBatchSize)
   }
 
-  def get(inputs: List[T]): Clump[List[U]] =
-    Clump.collect(inputs.map(get))
+  def list(inputs: List[T]): Clump[List[U]] = {
+    Clump.collect(inputs.map(get)).map(_.flatten)
+  }
 
-  def get(input: T): Clump[U] = {
+  def get(input: T): Clump[Option[U]] = {
     val fetcher = ClumpContext().fetcherFor(this)
     fetcher.append(input)
-    new ClumpFetch(input, fetcher)
+    new ClumpGetFetch(input, fetcher)
+  }
+
+  def getOrElse(input: T, default: U): Clump[U] = {
+    val fetcher = ClumpContext().fetcherFor(this)
+    fetcher.append(input)
+    new ClumpGetOrElseFetch(input, default, fetcher)
+  }
+
+  def apply(input: T): Clump[U] = {
+    val fetcher = ClumpContext().fetcherFor(this)
+    fetcher.append(input)
+    new ClumpApplyFetch(input, fetcher)
   }
 }

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -32,29 +32,29 @@ class ClumpExecutionSpec extends Spec {
         Clump.traverse(List(1, 2, 3, 4)) {
           i =>
             if (i <= 2)
-              source1.get(i)
+              source1(i)
             else
-              source2.get(i)
+              source2(i)
         }
 
-      clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
+      clumpResult(clump) ==== List(10, 20, 30, 40)
       source1Fetches mustEqual List(Set(1, 2))
       source2Fetches mustEqual List(Set(3, 4))
     }
 
     "for multiple clumps collected into only one clump" in new Context {
-      val clump = Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
+      val clump = Clump.collect(source1(1), source1(2), source2(3), source2(4))
 
-      clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
+      clumpResult(clump) ==== List(10, 20, 30, 40)
       source1Fetches mustEqual List(Set(1, 2))
       source2Fetches mustEqual List(Set(3, 4))
     }
 
     "for clumps created inside nested flatmaps" in new Context {
-      val clump1 = Clump.value(1).flatMap(source1.get(_)).flatMap(source2.get(_))
-      val clump2 = Clump.value(2).flatMap(source1.get(_)).flatMap(source2.get(_))
+      val clump1 = Clump.value(1).flatMap(source1(_)).flatMap(source2(_))
+      val clump2 = Clump.value(2).flatMap(source1(_)).flatMap(source2(_))
 
-      clumpResult(Clump.collect(clump1, clump2)) mustEqual Some(List(100, 200))
+      clumpResult(Clump.collect(clump1, clump2)) ==== List(100, 200)
       source1Fetches mustEqual List(Set(1, 2))
       source2Fetches mustEqual List(Set(20, 10))
     }
@@ -64,10 +64,10 @@ class ClumpExecutionSpec extends Spec {
       "one level" in new Context {
         val clump =
           for {
-            int <- Clump.collect(source1.get(1), source1.get(2), source2.get(3), source2.get(4))
+            int <- Clump.collect(source1(1), source1(2), source2(3), source2(4))
           } yield int
 
-        clumpResult(clump) mustEqual Some(List(10, 20, 30, 40))
+        clumpResult(clump) ==== (List(10, 20, 30, 40))
         source1Fetches mustEqual List(Set(1, 2))
         source2Fetches mustEqual List(Set(3, 4))
       }
@@ -75,51 +75,39 @@ class ClumpExecutionSpec extends Spec {
       "two levels" in new Context {
         val clump =
           for {
-            ints1 <- Clump.collect(source1.get(1), source1.get(2))
-            ints2 <- Clump.collect(source2.get(3), source2.get(4))
+            ints1 <- Clump.collect(source1(1), source1(2))
+            ints2 <- Clump.collect(source2(3), source2(4))
           } yield (ints1, ints2)
 
-        clumpResult(clump) mustEqual Some(List(10, 20), List(30, 40))
+        clumpResult(clump) ==== (List(10, 20), List(30, 40))
         source1Fetches mustEqual List(Set(1, 2))
         source2Fetches mustEqual List(Set(3, 4))
-      }
-
-      "with a filter condition" in new Context {
-        val clump =
-          for {
-            ints1 <- Clump.collect(source1.get(1), source1.get(2))
-            int2 <- source2.get(3) if (int2 != 999)
-          } yield (ints1, int2)
-
-        clumpResult(clump) mustEqual Some(List(10, 20), 30)
-        source1Fetches mustEqual List(Set(1, 2))
-        source2Fetches mustEqual List(Set(3))
       }
 
       "using a join" in new Context {
         val clump =
           for {
-            ints1 <- Clump.collect(source1.get(1), source1.get(2))
-            ints2 <- source2.get(3).join(source2.get(4))
+            ints1 <- Clump.collect(source1(1), source1(2))
+            ints2 <- source2(3).join(source2(4))
           } yield (ints1, ints2)
 
-        clumpResult(clump) mustEqual Some(List(10, 20), (30, 40))
+        clumpResult(clump) ==== (List(10, 20), (30, 40))
         source1Fetches mustEqual List(Set(1, 2))
         source2Fetches mustEqual List(Set(3, 4))
       }
 
       "complex scenario" in new Context {
-        val clump =
+        val clump: Clump[(Int, Int, List[Int], List[Int], (Int, Int), (List[Int], Int))] =
           for {
             const1 <- Clump.value(1)
             const2 <- Clump.value(2)
-            collect1 <- Clump.collect(source1.get(const1), source2.get(const2))
-            collect2 <- Clump.collect(source1.get(const1), source2.get(const2)) if (true)
+            collect1 <- Clump.collect(source1(const1), source2(const2))
+            collect2 <- Clump.collect(source1(const1), source2(const2))
             join1 <- Clump.value(4).join(Clump.value(5))
-            join2 <- source1.get(collect1).join(source2.get(join1._2))
+            join2 <- source1.list(collect1).join(source2(join1._2))
           } yield (const1, const2, collect1, collect2, join1, join2)
 
-        clumpResult(clump) mustEqual Some((1, 2, List(10, 20), List(10, 20), (4, 5), (List(100, 200), 50)))
+        clumpResult(clump) ==== (1, 2, List(10, 20), List(10, 20), (4, 5), (List(100, 200), 50))
         source1Fetches mustEqual List(Set(1), Set(10, 20))
         source2Fetches mustEqual List(Set(2), Set(5))
       }
@@ -135,13 +123,20 @@ class ClumpExecutionSpec extends Spec {
       promise
     }
 
-    source1.get(1).join(source2.get(2)).run
+    source1(1).join(source2(2)).run
 
-    promises.size mustEqual 2
+    promises.size ==== 2
   }
 
   "short-circuits the computation in case of a failure" in new Context {
     val clump = Clump.exception[Int](new IllegalStateException).map(_ => throw new NullPointerException)
-    clumpResult(clump) must throwA[IllegalStateException]
+
+    try {
+      clumpResult(clump)
+      ko("expected IllegalStateException")
+    } catch {
+      case e: IllegalStateException => ok
+      case _: Throwable => ko("expected IllegalStateException")
+    }
   }
 }

--- a/src/test/scala/clump/ClumpFetcherSpec.scala
+++ b/src/test/scala/clump/ClumpFetcherSpec.scala
@@ -25,13 +25,13 @@ class ClumpFetcherSpec extends Spec {
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
 
-    val clump1 = Clump.traverse(List(1, 2))(source.get)
+    val clump1 = Clump.traverse(List(1, 2))(source.apply)
 
-    clumpResult(clump1) mustEqual Some(List(10, 20))
+    clumpResult(clump1) ==== List(10, 20)
 
-    val clump2 = Clump.traverse(List(2, 3))(source.get)
+    val clump2 = Clump.traverse(List(2, 3))(source.apply)
 
-    clumpResult(clump2) mustEqual Some(List(20, 30))
+    clumpResult(clump2) ==== List(20, 30)
 
     verify(repo).fetch(Set(1, 2))
     verify(repo).fetch(Set(3))
@@ -44,9 +44,9 @@ class ClumpFetcherSpec extends Spec {
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
 
-    val clump = Clump.traverse(List(1, 2, 3))(source.get)
+    val clump = Clump.traverse(List(1, 2, 3))(source.apply)
 
-    clumpResult(clump) mustEqual Some(List(10, 20, 30))
+    clumpResult(clump) ==== List(10, 20, 30)
 
     verify(repo).fetch(Set(1, 2))
     verify(repo).fetch(Set(3))
@@ -60,8 +60,8 @@ class ClumpFetcherSpec extends Spec {
       .thenReturn(Future.exception(new IllegalStateException))
       .thenReturn(Future(Map(1 -> 10)))
 
-    clumpResult(source.get(1)) must throwA[IllegalStateException]
-    clumpResult(source.get(1)) mustEqual Some(10)
+    clumpResult(source(1)) must throwA[IllegalStateException]
+    clumpResult(source(1)) ==== 10
 
     verify(repo, times(2)).fetch(Set(1))
     verifyNoMoreInteractions(repo)

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -25,7 +25,7 @@ class ClumpSourceSpec extends Spec {
 
     when(repo.fetch(Set(1))).thenReturn(Future(Map(1 -> 2)))
 
-    clumpResult(source.get(1)) mustEqual Some(2)
+    clumpResult(source(1)) ==== 2
 
     verify(repo).fetch(Set(1))
     verifyNoMoreInteractions(repo)
@@ -36,9 +36,9 @@ class ClumpSourceSpec extends Spec {
 
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
-    val clump = source.get(List(1, 2))
+    val clump = source.list(List(1, 2))
 
-    clumpResult(clump) mustEqual Some(List(10, 20))
+    clumpResult(clump) ==== List(10, 20)
 
     verify(repo).fetch(Set(1, 2))
     verifyNoMoreInteractions(repo)
@@ -53,7 +53,7 @@ class ClumpSourceSpec extends Spec {
       Future.collect {
         for (i <- 0 until 5) yield {
           Future.Unit.flatMap { _ =>
-            source.get(List(1)).run
+            source.list(List(1)).run
           }
         }
       }

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -7,17 +7,17 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class IntegrationSpec extends Spec {
   val tweetRepository = new TweetRepository
+  val filteredTweetRepository = new FilteredTweetRepository
   val userRepository = new UserRepository
   val filteredUserRepository = new FilteredUserRepository
-  val filteredUserOptionRepository = new FilteredUserOptionRepository
   val timelineRepository = new TimelineRepository
   val likeRepository = new LikeRepository
   val trackRepository = new TrackRepository
 
   val tweets = Clump.sourceFrom(tweetRepository.tweetsFor)
+  val filteredTweets = Clump.source(filteredTweetRepository.tweetsFor) { _.tweetId }
   val users = Clump.sourceFrom(userRepository.usersFor)
   val filteredUsers = Clump.source(filteredUserRepository.usersFor) { _.userId }
-  val filteredOptionUsers = Clump.source(filteredUserOptionRepository.usersFor) { _.userId } // doesn't compile because this should be an option
   val timelines = Clump.source(timelineRepository.timelinesFor) { _.timelineId }
   val likes = Clump.source(likeRepository.likesFor) { _.likeId }
   val tracks = Clump.source(trackRepository.tracksFor) { _.trackId }
@@ -25,80 +25,82 @@ class IntegrationSpec extends Spec {
   "A Clump should batch calls to services" in {
     val enrichedTweets = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
         for {
-          tweet <- tweets.get(tweetId)
-          user <- users.get(tweet.userId)
+          tweet <- tweets(tweetId)
+          user <- users(tweet.userId)
         } yield (tweet, user)
       }
 
-    Await.result(enrichedTweets.run) ==== Some(List(
-      (Tweet("Tweet1", 10), User(10, "User10")),
-      (Tweet("Tweet2", 20), User(20, "User20")),
-      (Tweet("Tweet3", 30), User(30, "User30"))))
+    Await.result(enrichedTweets.run) ==== List(
+      (Tweet(1, "Tweet1", 10), User(10, "User10")),
+      (Tweet(2, "Tweet2", 20), User(20, "User20")),
+      (Tweet(3, "Tweet3", 30), User(30, "User30")))
   }
 
   "it should be able to be used in complex nested fetches" in {
     val timelineIds = List(1, 3)
     val enrichedTimelines = Clump.traverse(timelineIds) { id =>
         for {
-          timeline <- timelines.get(id)
+          timeline <- timelines(id)
           enrichedLikes <- Clump.traverse(timeline.likeIds) { id =>
             for {
-              like <- likes.get(id)
-              resources <- tracks.get(like.trackIds).join(users.get(like.userIds))
+              like <- likes(id)
+              resources <- tracks.list(like.trackIds).join(users.list(like.userIds))
             } yield (like, resources._1, resources._2)
           }
         } yield (timeline, enrichedLikes)
       }
 
-    Await.result(enrichedTimelines.run) ==== Some(List(
+    Await.result(enrichedTimelines.run) ==== List(
       (Timeline(1, List(10, 20)), List(
         (Like(10, List(100, 200), List(1000, 2000)), List(Track(100, "Track100"), Track(200, "Track200")), List(User(1000, "User1000"), User(2000, "User2000"))),
         (Like(20, List(200, 400), List(2000, 4000)), List(Track(200, "Track200"), Track(400, "Track400")), List(User(2000, "User2000"), User(4000, "User4000"))))),
       (Timeline(3, List(30, 60)), List(
         (Like(30, List(300, 600), List(3000, 6000)), List(Track(300, "Track300"), Track(600, "Track600")), List(User(3000, "User3000"), User(6000, "User6000"))),
-        (Like(60, List(600, 1200), List(6000, 12000)), List(Track(600, "Track600"), Track(1200, "Track1200")), List(User(6000, "User6000"), User(12000, "User12000")))))))
+        (Like(60, List(600, 1200), List(6000, 12000)), List(Track(600, "Track600"), Track(1200, "Track1200")), List(User(6000, "User6000"), User(12000, "User12000"))))))
   }
 
   "it should be usable with regular maps and flatMaps" in {
     val tweetIds = List(1L, 2L, 3L)
     val enrichedTweets: Clump[List[(Tweet, User)]] =
       Clump.traverse(tweetIds) { tweetId =>
-        tweets.get(tweetId).flatMap(tweet =>
-          users.get(tweet.userId).map(user => (tweet, user)))
+        tweets(tweetId).flatMap(tweet =>
+          users(tweet.userId).map(user => (tweet, user)))
       }
 
-    Await.result(enrichedTweets.run) ==== Some(List(
-      (Tweet("Tweet1", 10), User(10, "User10")),
-      (Tweet("Tweet2", 20), User(20, "User20")),
-      (Tweet("Tweet3", 30), User(30, "User30"))))
+    Await.result(enrichedTweets.run) ==== List(
+      (Tweet(1, "Tweet1", 10), User(10, "User10")),
+      (Tweet(2, "Tweet2", 20), User(20, "User20")),
+      (Tweet(3, "Tweet3", 30), User(30, "User30")))
   }
 
   "A Clump can have a partial result" in {
-    val enrichedTweets:Clump[List[(Tweet, User)]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
+    val enrichedTweets:Clump[List[(Tweet, Option[User])]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- filteredUsers.get(tweet.userId)
-      } yield (tweet, user)
+        tweet <- tweets(tweetId)
+        userOption <- filteredUsers.get(tweet.userId)
+      } yield (tweet, userOption)
     }
 
-    Await.result(enrichedTweets.run) ==== Some(List((Tweet("Tweet2", 20), User(20, "User20"))))
+    Await.result(enrichedTweets.run) ==== List(
+      (Tweet(1, "Tweet1", 10), None),
+      (Tweet(2, "Tweet2", 20), Some(User(20, "User20"))),
+      (Tweet(3, "Tweet3", 30), None))
 
-    val enrichedTweets2:Clump[List[(Tweet, Option[User])]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
+    val enrichedTweets2:Clump[List[(Option[Tweet], Option[User])]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- filteredOptionUsers.get(tweet.userId)
-      } yield (tweet, Some(user))
+        tweetOption <- filteredTweets.get(tweetId)
+        userOption <- Clump.collect(tweetOption.map(tweet => users.get(tweet.userId))).map(_.flatten)
+      } yield (tweetOption, userOption)
     }
 
-    // no nice way to do this
-    Await.result(enrichedTweets2.run) ==== Some(List(
-      (Tweet("Tweet1", 10), None),
-      (Tweet("Tweet2", 20), Some(User(20, "User20"))),
-      (Tweet("Tweet3", 30), None)))
+    Await.result(enrichedTweets2.run) ==== List(
+      (None, None),
+      (Some(Tweet(2, "Tweet2", 20)), Some(User(20, "User20"))),
+      (None, None))
   }
 }
 
-case class Tweet(body: String, userId: Long)
+case class Tweet(tweetId: Long, body: String, userId: Long)
 
 case class User(userId: Long, name: String)
 
@@ -110,7 +112,13 @@ case class Track(trackId: Long, name: String)
 
 class TweetRepository {
   def tweetsFor(ids: Set[Long]): Future[Map[Long, Tweet]] = {
-    Future.value(ids.map(id => id -> Tweet(s"Tweet$id", id * 10)).toMap)
+    Future.value(ids.map(id => id -> Tweet(id, s"Tweet$id", id * 10)).toMap)
+  }
+}
+
+class FilteredTweetRepository {
+  def tweetsFor(ids: Set[Long]): Future[Set[Tweet]] = {
+    Future.value(ids.filter(_ % 2 == 0).map(id => Tweet(id, s"Tweet$id", id * 10)))
   }
 }
 
@@ -123,12 +131,6 @@ class UserRepository {
 class FilteredUserRepository {
   def usersFor(ids: Set[Long]): Future[Set[User]] = {
     Future.value(ids.filter(_ % 20 == 0).map(id => User(id, s"User$id")))
-  }
-}
-
-class FilteredUserOptionRepository {
-  def usersFor(ids: Set[Long]): Future[Set[Option[User]]] = {
-    Future.value(ids.map(id => if (id % 20 == 0) None else Some(User(id, s"User$id"))))
   }
 }
 


### PR DESCRIPTION
This is a reaction to shortcomings described in https://github.com/fwbrasil/clump/pull/17 and https://github.com/fwbrasil/clump/issues/18

[`clump.run`](https://github.com/fwbrasil/clump/blob/390e0b6c46745e59666410defa3a1eb12521014d/src/main/scala/clump/Clump.scala#L23) now returns `Future[U]` instead of `Future[Option[U]]`

[Change ClumpSource](https://github.com/fwbrasil/clump/blob/390e0b6c46745e59666410defa3a1eb12521014d/src/main/scala/clump/ClumpSource.scala) to allow more fine-tuned fetching: `get`/`getOrElse`/`apply` so the user may decide the behavior when items are not found

This allows users to decide what the behavior should be when secondary resources are not found. Rather than always making the whole thing be a None, they may choose [partial responses](https://github.com/fwbrasil/clump/blob/390e0b6c46745e59666410defa3a1eb12521014d/src/test/scala/clump/IntegrationSpec.scala#L76), or [default response](https://github.com/fwbrasil/clump/blob/390e0b6c46745e59666410defa3a1eb12521014d/src/main/scala/clump/ClumpSource.scala#L21)

@fwbrasil I really think we should merge this
