### PR TITLE
use a covariant generic for Clumps

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -4,7 +4,7 @@ import com.twitter.util.Future
 import com.twitter.util.Throw
 import com.twitter.util.Try
 
-trait Clump[T] {
+trait Clump[+T] {
 
   private val forceContextInit = ClumpContext()
 
@@ -14,11 +14,11 @@ trait Clump[T] {
 
   def join[U](other: Clump[U]): Clump[(T, U)] = new ClumpJoin(this, other)
 
-  def handle(f: Throwable => T): Clump[T] = rescue(f.andThen(Clump.value(_)))
+  def handle[B >: T](f: Throwable => B): Clump[B] = rescue[B](f.andThen(Clump.value(_)))
 
-  def rescue(f: Throwable => Clump[T]): Clump[T] = new ClumpRescue(this, f)
+  def rescue[B >: T](f: Throwable => Clump[B]): Clump[B] = new ClumpRescue(this, f)
 
-  def withFilter(f: T => Boolean) = new ClumpFilter(this, f)
+  def withFilter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
 
   def run = Future.Unit.flatMap(_ => result)
 

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -107,5 +107,13 @@ class ClumpApiSpec extends Spec {
       clumpResult(Clump.value(1).withFilter(_ != 1)) mustEqual None
       clumpResult(Clump.value(1).withFilter(_ == 1)) mustEqual Some(1)
     }
+    
+    "uses a covariant type parameter" in {
+      trait A
+      class B extends A
+      class C extends A
+      val clump = Clump.traverse(List(new B, new C))(Clump.value(_))
+      (clump: Clump[List[A]]) must beAnInstanceOf[Clump[List[A]]]
+    }
   }
 }


### PR DESCRIPTION
@williamboxhall I had compilation issues using `Clump` and the solution is use a covariant generic, similarly to the Twitter's Future:

https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Future.scala#L627
