### PR TITLE
Clump.list

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -20,6 +20,8 @@ trait Clump[+T] {
 
   def withFilter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
 
+  def list[B](implicit ev: T <:< List[B]): Future[List[B]] = get.map(_.toList.flatten)
+
   def get: Future[Option[T]] = Future.Unit.flatMap(_ => result)
 
   protected def result: Future[Option[T]]

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -115,5 +115,10 @@ class ClumpApiSpec extends Spec {
       val clump = Clump.traverse(List(new B, new C))(Clump.value(_))
       (clump: Clump[List[A]]) must beAnInstanceOf[Clump[List[A]]]
     }
+
+    "can represent its result as a list (clump.list) when its type is List[T]" in {
+      Await.result(Clump.value(List(1,2)).list) ==== List(1,2)
+      // Clump.value(1).list doesn't compile
+    }
   }
 }

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -68,6 +68,20 @@ class IntegrationSpec extends Spec {
       (Tweet("Tweet2", 20), User(20, "User20")),
       (Tweet("Tweet3", 30), User(30, "User30"))))
   }
+
+  "it should allow unwrapping Clumped lists with clump.list" in {
+    val enrichedTweets: Clump[List[(Tweet, User)]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
+      for {
+        tweet <- tweets.get(tweetId)
+        user <- users.get(tweet.userId)
+      } yield (tweet, user)
+    }
+
+    Await.result(enrichedTweets.list) ==== List(
+      (Tweet("Tweet1", 10), User(10, "User10")),
+      (Tweet("Tweet2", 20), User(20, "User20")),
+      (Tweet("Tweet3", 30), User(30, "User30")))
+  }
 }
 
 case class Tweet(body: String, userId: Long)


### PR DESCRIPTION
@fwbrasil I was not clever enough with generics to figure out how to do this for the general case, like the way `flatten` works for any type of collection (`Set`, `List`, etc.). However I think this will fulfill the majority of cases since people can combine it with traverse which returns a `Clump[List[T]]`

On naming: I originally called this `flatRun` to line up with `.map(...).flatten => .flatMap`, however I think `list` is a lot clearer and also reads better. I also think maybe `clump.get` might be a better name than `clump.run` because `clump.get` aligns well with `map.get` which returns an `Option`
