### PR TITLE
[WIP] allow all functions to be passed to Clump.source(...)

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -51,8 +51,8 @@ object Clump {
   def sourceFrom[T, U](fetch: Set[T] => Future[Map[T, U]], maxBatchSize: Int = Int.MaxValue) =
     new ClumpSource(fetch, maxBatchSize)
 
-  def source[T, U](fetch: Set[T] => Future[Iterable[U]], maxBatchSize: Int = Int.MaxValue)(keyFn: U => T) =
-    new ClumpSource(fetch, keyFn, maxBatchSize)
+  def source[T, U, In <: Iterable[T], Out <: Iterable[U]](fetch: In => Future[Out], maxBatchSize: Int = Int.MaxValue)(keyFn: U => T) =
+    ClumpSource.create(fetch, keyFn, maxBatchSize)
 }
 
 class ClumpFuture[T](future: Future[Option[T]]) extends Clump[T] {
@@ -75,7 +75,7 @@ class ClumpCollect[T](list: List[Clump[T]]) extends Clump[List[T]] {
       .map(Some(_))
 }
 
-class ClumpFetch[T, U](input: T, fetcher: ClumpFetcher[T, U]) extends Clump[U] {
+class ClumpFetch[T, U, In <: Iterable[T], Out <: Iterable[U]](input: T, fetcher: ClumpFetcher[T, U, In, Out]) extends Clump[U] {
   lazy val result = fetcher.run(input)
 }
 

--- a/src/main/scala/clump/ClumpContext.scala
+++ b/src/main/scala/clump/ClumpContext.scala
@@ -6,13 +6,13 @@ import scala.collection.mutable.SynchronizedMap
 
 class ClumpContext {
 
-  private val fetchers = new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
+  private val fetchers = new HashMap[ClumpSource[_, _, _, _], ClumpFetcher[_, _, _, _]]()
 
-  def fetcherFor[T, U](source: ClumpSource[T, U]) =
+  def fetcherFor[T, U, In <: Iterable[T], Out <: Iterable[U]](source: ClumpSource[T, U, In, Out]) =
     synchronized {
       fetchers
         .getOrElseUpdate(source, new ClumpFetcher(source))
-        .asInstanceOf[ClumpFetcher[T, U]]
+        .asInstanceOf[ClumpFetcher[T, U, In, Out]]
     }
 }
 

--- a/src/main/scala/clump/ClumpFetcher.scala
+++ b/src/main/scala/clump/ClumpFetcher.scala
@@ -2,7 +2,7 @@ package clump
 
 import com.twitter.util.Future
 
-class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
+class ClumpFetcher[T, U, In <: Iterable[T], Out <: Iterable[U]](source: ClumpSource[T, U, In, Out]) {
 
   private var pending = Set[T]()
   private var fetched = Map[T, Future[Option[U]]]()
@@ -27,7 +27,7 @@ class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
       fetch
     }
 
-  private def fetchInBatches(toFetch: Set[T]) =
+  private def fetchInBatches(toFetch: In) =
     Future.collect {
       toFetch.grouped(source.maxBatchSize).toList.map { batch =>
         val results = source.fetch(batch)

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -4,6 +4,8 @@ import com.twitter.util.{Await, Future}
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 
+import scalaz.Functor
+
 @RunWith(classOf[JUnitRunner])
 class IntegrationSpec extends Spec {
   val tweetRepository = new TweetRepository
@@ -67,6 +69,21 @@ class IntegrationSpec extends Spec {
       (Tweet("Tweet1", 10), User(10, "User10")),
       (Tweet("Tweet2", 20), User(20, "User20")),
       (Tweet("Tweet3", 30), User(30, "User30"))))
+  }
+
+  "foo" in {
+    val setToSet: Set[Int] => Set[String] = { _.map(_.toString + "potato")}
+    val listToList: List[Int] => List[String] = { _.map(_.toString + "tomato")}
+    val listToIterable: List[Int] => Iterable[String] = { _.map(_.toString + "ristretto")}
+    println(setToSet(Set(1,2)))
+    println(listToList(List(1,2)))
+    println(listToIterable(List(1,2)))
+
+    def applyer[In <: Iterable[Int], Out <: Iterable[String]](fn: In => Out)(inputs: In): Out = fn(inputs)
+    println(applyer(setToSet)(Set(1,2)))
+    println(applyer(listToList)(List(1,2)))
+    println(applyer(listToIterable)(List(1,2)))
+    ok
   }
 }
 


### PR DESCRIPTION
@fwbrasil this doesn't compile. I was just trying to allow and subclass of iterable to be used in Clump.source. I have the generics working however I don't know what to do when we actually invoke the fetch function, since we have to convert from a `Set[T]` to an `In`. I think you can do some magic with `CanBuildFrom` stuff but it's a bit over my head and now I am too tired to keep looking at it today :)

I still think it would be nice to have the flexibility here, WDYT?