### PR TITLE
allow to use a clump for the 'orElse' default value

### DIFF
--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -18,7 +18,7 @@ class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize
     new ClumpFetch(input, ClumpContext().fetcherFor(this))
   
   def getOrElse(input: T, default: => U) =
-    get(input).orElse(default)
+    get(input).orElse(Clump.value(default))
 
   def apply(input: T): Clump[U] =
     get(input).orElse(throw new NoSuchElementException)

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -149,7 +149,7 @@ class ClumpApiSpec extends Spec {
     }
 
     "result can never be None after clump.orElse" in {
-      clumpResult(Clump.None.orElse(1)) ==== Some(1)
+      clumpResult(Clump.None.orElse(Clump.value(1))) ==== Some(1)
     }
 
     "can represent its result as a list (clump.list) when its type is List[T]" in {

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -148,8 +148,13 @@ class ClumpApiSpec extends Spec {
       (clump: Clump[List[A]]) must beAnInstanceOf[Clump[List[A]]]
     }
 
-    "result can never be None after clump.orElse" in {
-      clumpResult(Clump.None.orElse(Clump.value(1))) ==== Some(1)
+    "allows to defined a fallback value (clump.orElse)" >> {
+      "undefined" in {
+        clumpResult(Clump.None.orElse(Clump.value(1))) ==== Some(1)
+      }
+      "defined" in {
+        clumpResult(Clump.value(Some(1)).orElse(Clump.value(2))) ==== Some(1)
+      }
     }
 
     "can represent its result as a list (clump.list) when its type is List[T]" in {


### PR DESCRIPTION
@williamboxhall I think ```orElse``` is more flexible and useful if it receives a clump instead of a value. An actual value it more useful for ```getOrElse```, that is unchanged.