### PR TITLE
fix the apply method

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -29,7 +29,7 @@ trait Clump[+T] {
 
   def optional: Clump[Option[T]] = new ClumpOptional(this)
 
-  def apply: Future[T] = get.map(_.get)
+  def apply(): Future[T] = get.map(_.get)
 
   def get: Future[Option[T]] =
     context

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -168,15 +168,8 @@ class ClumpApiSpec extends Spec {
     }
 
     "has a utility method (clump.apply) for unwrapping optional result" in {
-      Clump.value(1).apply() ==== 1
-
-      try {
-        Clump.None.apply()
-        ko("expected NoSuchElementException to be thrown")
-      } catch {
-        case e: NoSuchElementException => ok
-        case e: Throwable              => ko(s"expected NoSuchElementException but was $e")
-      }
+      Await.result(Clump.value(1).apply()) ==== 1
+      Await.result(Clump.value[Int](None)()) must throwA[NoSuchElementException]
     }
 
     "can be made optional (clump.optional) to avoid lossy joins" in {


### PR DESCRIPTION
@williamboxhall The ```()``` was missing for ```apply```. The consequence is that when using ```clump.apply()```, you are actually using the Clump's ```apply``` and then the Future's ```apply```[1], that is a blocking operation.

[1] https://github.com/twitter/util/blob/master/util-core/src/main/scala/com/twitter/util/Future.scala#L655