### PR TITLE
simplify the ClumSource's interface

### DIFF
--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -8,22 +8,14 @@ class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize
     this(fetch.andThen(_.map(_.map(v => (keyFn(v), v)).toMap)), maxBatchSize)
   }
 
-  def list(inputs: T*): Clump[List[U]] =
-    list(inputs.toList)
+  def get(inputs: T*): Clump[List[U]] =
+    get(inputs.toList)
 
-  def list(inputs: List[T]): Clump[List[U]] =
+  def get(inputs: List[T]): Clump[List[U]] =
     Clump.collect(inputs.map(get))
 
   def get(input: T): Clump[U] =
     new ClumpFetch(input, ClumpContext().fetcherFor(this))
-  
-  def getOrElse(input: T, default: => U) =
-    get(input).orElse(Clump.value(default))
-
-  def apply(input: T): Clump[U] =
-    get(input).orElse(throw new NoSuchElementException)
-
-  def optional(input: T): Clump[Option[U]] = get(input).optional
 }
 
 object ClumpSource {

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -142,7 +142,7 @@ class ClumpExecutionSpec extends Spec {
             collect1 <- Clump.collect(source1.get(const1), source2.get(const2))
             collect2 <- Clump.collect(source1.get(const1), source2.get(const2)) if (true)
             join1 <- Clump.value(4).join(Clump.value(5))
-            join2 <- source1.list(collect1).join(source2.get(join1._2))
+            join2 <- source1.get(collect1).join(source2.get(join1._2))
           } yield (const1, const2, collect1, collect2, join1, join2)
 
         clumpResult(clump) mustEqual Some((1, 2, List(10, 20), List(10, 20), (4, 5), (List(100, 200), 50)))

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -31,17 +31,6 @@ class ClumpSourceSpec extends Spec {
     verifyNoMoreInteractions(repo)
   }
 
-  "provides failfast, fallbacks and optional when fetching" in new Context {
-    val source = Clump.sourceFrom(repo.fetch)
-
-    when(repo.fetch(Set(1))).thenReturn(Future(Map[Int, Int]()))
-
-    clumpResult(source.get(1)) ==== None
-    clumpResult(source.getOrElse(1, 2)) ==== Some(2)
-    clumpResult(source(1)) must throwA[NoSuchElementException]
-    clumpResult(source.optional(1)) ==== Some(None)
-  }
-
   "fetches multiple clumps" >> {
 
     "using list" in new Context {
@@ -49,7 +38,7 @@ class ClumpSourceSpec extends Spec {
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
-      val clump = source.list(List(1, 2))
+      val clump = source.get(List(1, 2))
 
       clumpResult(clump) mustEqual Some(List(10, 20))
 
@@ -62,7 +51,7 @@ class ClumpSourceSpec extends Spec {
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
-      val clump = source.list(1, 2)
+      val clump = source.get(1, 2)
 
       clumpResult(clump) mustEqual Some(List(10, 20))
 
@@ -79,7 +68,7 @@ class ClumpSourceSpec extends Spec {
     val future =
       Future.collect {
         for (i <- 0 until 5) yield {
-          source.list(List(1)).get
+          source.get(List(1)).get
         }
       }
 

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -44,7 +44,7 @@ class IntegrationSpec extends Spec {
           enrichedLikes <- Clump.traverse(timeline.likeIds) { id =>
             for {
               like <- likes.get(id)
-              resources <- tracks.list(like.trackIds).join(users.list(like.userIds))
+              resources <- tracks.get(like.trackIds).join(users.get(like.userIds))
             } yield (like, resources._1, resources._2)
           }
         } yield (timeline, enrichedLikes)
@@ -114,7 +114,7 @@ class IntegrationSpec extends Spec {
     val partialResponses: Clump[List[(Tweet, Option[User])]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
         tweet <- tweets.get(tweetId)
-        user <- filteredUsers.optional(tweet.userId)
+        user <- filteredUsers.get(tweet.userId).optional
       } yield (tweet, user)
     }
 


### PR DESCRIPTION
@williamboxhall I find the current ```ClumpSource``` interface confusing. It requires the user to understand the differences between ```list```, ```get```,```getOrElse``` and ```apply```. Considering that the features introduced by the different methods are also provided by the ```Clump``` instances, I think we should remove them.

After the change, the source's interface is really simple, the user needs to use only ```get```.