### PR TITLE
don't allow the user extend the Clump's classes

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -5,7 +5,7 @@ import com.twitter.util.Throw
 import com.twitter.util.Try
 import com.twitter.util.Return
 
-trait Clump[+T] {
+sealed trait Clump[+T] {
 
   private val context = ClumpContext()
 

--- a/src/main/scala/clump/ClumpContext.scala
+++ b/src/main/scala/clump/ClumpContext.scala
@@ -7,7 +7,7 @@ import com.twitter.util.Future
 import com.twitter.util.JavaTimer
 import com.twitter.util.TimeConversions._
 
-class ClumpContext {
+final class ClumpContext {
 
   private val fetchers =
     new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()

--- a/src/main/scala/clump/ClumpFetcher.scala
+++ b/src/main/scala/clump/ClumpFetcher.scala
@@ -4,7 +4,7 @@ import com.twitter.util.Future
 import scala.collection.mutable.{ Map => MutableMap }
 import com.twitter.util._
 
-class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
+final class ClumpFetcher[T, U](source: ClumpSource[T, U]) {
 
   private val fetches = MutableMap[T, Promise[Option[U]]]()
 

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -2,7 +2,7 @@ package clump
 
 import com.twitter.util.Future
 
-class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize: Int) {
+final class ClumpSource[T, U](val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize: Int) {
 
   def this(fetch: Set[T] => Future[Iterable[U]], keyFn: U => T, maxBatchSize: Int) = {
     this(fetch.andThen(_.map(_.map(v => (keyFn(v), v)).toMap)), maxBatchSize)


### PR DESCRIPTION
@williamboxhall This is more a precaution, I had issues in the past with users extending and overriding the library's classes. We can remove the limitation if necessary in the future.