### PR TITLE
Add ClumpSource creation methods to Clump object

### DIFF
--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -3,21 +3,15 @@ package clump
 import com.twitter.util.Future
 import scala.collection.generic.CanBuildFrom
 
-class ClumpSource[T, U] private (
-  val fetch: Set[T] => Future[Map[T, U]],
-  val maxBatchSize: Int = Int.MaxValue) {
+class ClumpSource[T, U] private (val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize: Int = Int.MaxValue) {
 
-  def get(inputs: T*): Clump[List[U]] =
-    get(inputs.toList)
+  def get(inputs: T*): Clump[List[U]] = get(inputs.toList)
 
-  def get(inputs: List[T]): Clump[List[U]] =
-    Clump.collect(inputs.map(get))
+  def get(inputs: List[T]): Clump[List[U]] = Clump.collect(inputs.map(get))
 
-  def get(input: T): Clump[U] =
-    new ClumpFetch(input, ClumpContext().fetcherFor(this))
+  def get(input: T): Clump[U] = new ClumpFetch(input, ClumpContext().fetcherFor(this))
 
-  def maxBatchSize(int: Int) =
-    new ClumpSource(fetch, maxBatchSize = int)
+  def maxBatchSize(size: Int): ClumpSource[T, U] = new ClumpSource(fetch, size)
 }
 
 object ClumpSource {

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -21,8 +21,8 @@ class ClumpExecutionSpec extends Spec {
       Future.value(inputs.map(i => i -> i * 10).toMap)
     }
 
-    val source1 = ClumpSource.from((i: Set[Int]) => fetchFunction(source1Fetches, i))
-    val source2 = ClumpSource.from((i: Set[Int]) => fetchFunction(source2Fetches, i))
+    val source1 = Clump.sourceFrom((i: Set[Int]) => fetchFunction(source1Fetches, i))
+    val source2 = Clump.sourceFrom((i: Set[Int]) => fetchFunction(source2Fetches, i))
   }
 
   "batches requests" >> {

--- a/src/test/scala/clump/ClumpFetcherSpec.scala
+++ b/src/test/scala/clump/ClumpFetcherSpec.scala
@@ -20,7 +20,7 @@ class ClumpFetcherSpec extends Spec {
   }
 
   "memoizes the results of previous fetches" in new Context {
-    val source = ClumpSource.from(repo.fetch)
+    val source = Clump.sourceFrom(repo.fetch)
 
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
@@ -39,7 +39,7 @@ class ClumpFetcherSpec extends Spec {
   }
 
   "limits the batch size" in new Context {
-    val source = ClumpSource.from(repo.fetch).maxBatchSize(2)
+    val source = Clump.sourceFrom(repo.fetch).maxBatchSize(2)
 
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
@@ -54,7 +54,7 @@ class ClumpFetcherSpec extends Spec {
   }
 
   "retries failed fetches" in new Context {
-    val source = ClumpSource.from(repo.fetch)
+    val source = Clump.sourceFrom(repo.fetch)
 
     when(repo.fetch(Set(1)))
       .thenReturn(Future.exception(new IllegalStateException))

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -23,12 +23,12 @@ class ClumpSourceSpec extends Spec {
   "allows to create a clump source (ClumpSource.from)" >> {
     "set input" in {
       def fetch(inputs: Set[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
-      val source = ClumpSource.from(fetch)
+      val source = Clump.sourceFrom(fetch)
       clumpResult(source.get(1)) mustEqual Some("1")
     }
     "list input" in {
       def fetch(inputs: List[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
-      val source = ClumpSource.from(fetch)
+      val source = Clump.sourceFrom(fetch)
       clumpResult(source.get(1)) mustEqual Some("1")
     }
   }
@@ -36,24 +36,24 @@ class ClumpSourceSpec extends Spec {
   "allows to create a clump source with key function (ClumpSource.apply)" >> {
     "set input" in {
       def fetch(inputs: Set[Int]) = Future.value(inputs.map(_.toString))
-      val source = ClumpSource(fetch)(_.toInt)
+      val source = Clump.source(fetch)(_.toInt)
       clumpResult(source.get(1)) mustEqual Some("1")
     }
     "seq input" in {
       def fetch(inputs: Seq[Int]) = Future.value(inputs.map(_.toString))
-      val source = ClumpSource(fetch)(_.toInt)
+      val source = Clump.source(fetch)(_.toInt)
       clumpResult(source.get(1)) mustEqual Some("1")
     }
   }
 
   "allows to create a clump source with zip as the key function (ClumpSource.zip)" in {
     def fetch(inputs: List[Int]) = Future.value(inputs.map(_.toString))
-    val source = ClumpSource.zip(fetch)
+    val source = Clump.sourceZip(fetch)
     clumpResult(source.get(1)) mustEqual Some("1")
   }
 
   "fetches an individual clump" in new Context {
-    val source = ClumpSource.from(repo.fetch)
+    val source = Clump.sourceFrom(repo.fetch)
 
     when(repo.fetch(Set(1))).thenReturn(Future(Map(1 -> 2)))
 
@@ -66,7 +66,7 @@ class ClumpSourceSpec extends Spec {
   "fetches multiple clumps" >> {
 
     "using list" in new Context {
-      val source = ClumpSource.from(repo.fetch)
+      val source = Clump.sourceFrom(repo.fetch)
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
@@ -79,7 +79,7 @@ class ClumpSourceSpec extends Spec {
     }
 
     "using varargs" in new Context {
-      val source = ClumpSource.from(repo.fetch)
+      val source = Clump.sourceFrom(repo.fetch)
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
@@ -93,7 +93,7 @@ class ClumpSourceSpec extends Spec {
   }
 
   "can be used as a singleton" in new Context {
-    val source = ClumpSource.from(repo.fetch)
+    val source = Clump.sourceFrom(repo.fetch)
 
     when(repo.fetch(Set(1))).thenReturn(Future(Map(1 -> 2)))
 

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -14,13 +14,13 @@ class IntegrationSpec extends Spec {
   val likeRepository = new LikeRepository
   val trackRepository = new TrackRepository
 
-  val tweets = ClumpSource.from(tweetRepository.tweetsFor)
-  val users = ClumpSource.from(userRepository.usersFor)
-  val filteredUsers = ClumpSource(filteredUserRepository.usersFor) { _.userId }
-  val zippedUsers = ClumpSource.zip(zipUserRepository.usersFor)
-  val timelines = ClumpSource(timelineRepository.timelinesFor) { _.timelineId }
-  val likes = ClumpSource(likeRepository.likesFor) { _.likeId }
-  val tracks = ClumpSource(trackRepository.tracksFor) { _.trackId }
+  val tweets = Clump.sourceFrom(tweetRepository.tweetsFor)
+  val users = Clump.sourceFrom(userRepository.usersFor)
+  val filteredUsers = Clump.source(filteredUserRepository.usersFor) { _.userId }
+  val zippedUsers = Clump.sourceZip(zipUserRepository.usersFor)
+  val timelines = Clump.source(timelineRepository.timelinesFor) { _.timelineId }
+  val likes = Clump.source(likeRepository.likesFor) { _.likeId }
+  val tracks = Clump.source(trackRepository.tracksFor) { _.trackId }
 
   "A Clump should batch calls to services" in {
     val enrichedTweets = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>


### PR DESCRIPTION
As discussed in https://github.com/fwbrasil/clump/pull/35, I think it make things nice and simple to have one single entry point for using Clump.

I don't think the interface is too polluted like this

@fwbrasil let's discuss