### PR TITLE
Add extra test coverage for flexible sources for different types of iterables in and out

### DIFF
--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -52,7 +52,7 @@ class ClumpSourceSpec extends Spec {
     clumpResult(source.get(1)) mustEqual Some("1")
   }
 
-  "allows to create a clump source from various input/ouput type fetch functions (Clump.source)" in {
+  "allows to create a clump source from various input/ouput type fetch functions (ClumpSource.apply)" in {
     def setToSet: Set[Int] => Future[Set[String]] = { inputs => Future.value(inputs.map(_.toString)) }
     def listToList: List[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString)) }
     def iterableToIterable: Iterable[Int] => Future[Iterable[String]] = { inputs => Future.value(inputs.map(_.toString)) }
@@ -62,26 +62,35 @@ class ClumpSourceSpec extends Spec {
     def listToIterable: List[Int] => Future[Iterable[String]] = { inputs => Future.value(inputs.map(_.toString)) }
     def iterableToList: Iterable[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
     def iterableToSet: Iterable[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
+    
+    def testSource(source: ClumpSource[Int, String]) =
+      clumpResult(source.get(1, 2)) mustEqual Some(List("1", "2"))
+    
+    def extractId(string: String) = string.toInt
 
-    ClumpSource(setToSet) _
-    ClumpSource(listToList) _
-    ClumpSource(iterableToIterable) _
-    ClumpSource(setToList) _
-    ClumpSource(listToSet) _
-    ClumpSource(setToIterable) _
-    ClumpSource(listToIterable) _
-    ClumpSource(iterableToList) _
-    ClumpSource(iterableToSet) _
+    testSource(ClumpSource(setToSet)(extractId))
+    testSource(ClumpSource(listToList)(extractId))
+    testSource(ClumpSource(iterableToIterable)(extractId))
+    testSource(ClumpSource(setToList)(extractId))
+    testSource(ClumpSource(listToSet)(extractId))
+    testSource(ClumpSource(setToIterable)(extractId))
+    testSource(ClumpSource(listToIterable)(extractId))
+    testSource(ClumpSource(iterableToList)(extractId))
+    testSource(ClumpSource(iterableToSet)(extractId))
+  }
+  
+  "allows to create a clump source from various input/ouput type fetch functions (ClumpSource.from)" in {
 
     def setToMap: Set[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
     def listToMap: List[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
     def iterableToMap: Iterable[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
+    
+    def testSource(source: ClumpSource[Int, String]) =
+      clumpResult(source.get(1, 2)) mustEqual Some(List("1", "2"))
 
-    ClumpSource.from(setToMap) _
-    ClumpSource.from(listToMap) _
-    ClumpSource.from(iterableToMap) _
-
-    ok
+    testSource(ClumpSource.from(setToMap))
+    testSource(ClumpSource.from(listToMap))
+    testSource(ClumpSource.from(iterableToMap))
   }
 
   "fetches an individual clump" in new Context {

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -52,6 +52,38 @@ class ClumpSourceSpec extends Spec {
     clumpResult(source.get(1)) mustEqual Some("1")
   }
 
+  "allows to create a clump source from various input/ouput type fetch functions (Clump.source)" in {
+    def setToSet: Set[Int] => Future[Set[String]] = { inputs => Future.value(inputs.map(_.toString)) }
+    def listToList: List[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString)) }
+    def iterableToIterable: Iterable[Int] => Future[Iterable[String]] = { inputs => Future.value(inputs.map(_.toString)) }
+    def setToList: Set[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
+    def listToSet: List[Int] => Future[Set[String]] = { inputs => Future.value(inputs.map(_.toString).toSet) }
+    def setToIterable: Set[Int] => Future[Iterable[String]] = { inputs => Future.value(inputs.map(_.toString)) }
+    def listToIterable: List[Int] => Future[Iterable[String]] = { inputs => Future.value(inputs.map(_.toString)) }
+    def iterableToList: Iterable[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
+    def iterableToSet: Iterable[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
+
+    ClumpSource(setToSet) _
+    ClumpSource(listToList) _
+    ClumpSource(iterableToIterable) _
+    ClumpSource(setToList) _
+    ClumpSource(listToSet) _
+    ClumpSource(setToIterable) _
+    ClumpSource(listToIterable) _
+    ClumpSource(iterableToList) _
+    ClumpSource(iterableToSet) _
+
+    def setToMap: Set[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
+    def listToMap: List[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
+    def iterableToMap: Iterable[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
+
+    ClumpSource.from(setToMap) _
+    ClumpSource.from(listToMap) _
+    ClumpSource.from(iterableToMap) _
+
+    ok
+  }
+
   "fetches an individual clump" in new Context {
     val source = Clump.sourceFrom(repo.fetch)
 


### PR DESCRIPTION
@fwbrasil I don't have time to finish this now as I'm heading out for dinner.

I got all of this compiling for `ClumpSource.apply` however it won't compile for the `ClumpSource.from` eamples

Maybe you can take over if you have time, otherwise I can pick it up next time I have a chance