### PR TITLE
add a test proving that the new execution model can batch composition br...

### DIFF
--- a/src/main/scala/clump/ClumpContext.scala
+++ b/src/main/scala/clump/ClumpContext.scala
@@ -25,7 +25,7 @@ final class ClumpContext {
       case clumps =>
         flushUpstream(clumps).flatMap { _ =>
           flushDownstream(clumps).flatMap { _ =>
-            flushFetchers
+            flushFetches(clumps).unit
           }
         }
     }
@@ -38,8 +38,13 @@ final class ClumpContext {
       flush(down.flatten.toList)
     }
 
-  private def flushFetchers =
-    Future.collect(fetchers.values.map(_.flush).toList).unit
+  private def flushFetches(clumps: List[Clump[_]]) =
+    Future.collect(fetchersFor(clumps).map(_.flush))
+
+  private def fetchersFor(clumps: List[Clump[_]]) =
+    clumps.collect {
+      case clump: ClumpFetch[_, _] => clump.fetcher
+    }.distinct
 }
 
 object ClumpContext {

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -64,11 +64,15 @@ class ClumpExecutionSpec extends Spec {
     "for composition branches with different latencies" in new Context {
       implicit val timer = new JavaTimer
       val clump1 =
-        Clump.future(Future.value(Some(1)))
-          .flatMap(source1.get)
+        Clump.value(1).flatMap { int =>
+          Clump.future(Future.value(Some(int)))
+            .flatMap(source1.get)
+        }
       val clump2 =
-        Clump.future(Future.value(Some(2)).delayed(100 millis))
-          .flatMap(source1.get)
+        Clump.value(2).flatMap { int =>
+          Clump.future(Future.value(Some(int)).delayed(100 millis))
+            .flatMap(source1.get)
+        }
 
       val clump = Clump.collect(clump1, clump2)
 

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -8,6 +8,8 @@ import org.specs2.specification.Scope
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import com.twitter.util.Promise
+import com.twitter.util.JavaTimer
+import com.twitter.util.TimeConversions._
 
 @RunWith(classOf[JUnitRunner])
 class ClumpExecutionSpec extends Spec {
@@ -57,6 +59,21 @@ class ClumpExecutionSpec extends Spec {
       clumpResult(Clump.collect(clump1, clump2)) mustEqual Some(List(100, 200))
       source1Fetches mustEqual List(Set(1, 2))
       source2Fetches mustEqual List(Set(20, 10))
+    }
+
+    "for composition branches with different latencies" in new Context {
+      implicit val timer = new JavaTimer
+      val clump1 =
+        Clump.future(Future.value(Some(1)))
+          .flatMap(source1.get)
+      val clump2 =
+        Clump.future(Future.value(Some(2)).delayed(100 millis))
+          .flatMap(source1.get)
+
+      val clump = Clump.collect(clump1, clump2)
+
+      clumpResult(clump) mustEqual Some((List(10, 20)))
+      source1Fetches mustEqual List(Set(1, 2))
     }
 
     "for clumps composed using for comprehension" >> {
@@ -119,19 +136,6 @@ class ClumpExecutionSpec extends Spec {
         clumpResult(clump) mustEqual Some((List(10), List(10)))
         source1Fetches mustEqual List(Set(1))
         source2Fetches mustEqual List(Set(1))
-      }
-
-      "using nested flatmaps" in new Context {
-        val clump =
-          Clump.future(Future.value(Some(1))).flatMap { int =>
-            Clump.collect(source1.get(int + 1), source2.get(int + 2)).flatMap { ints =>
-              Clump.traverse(ints)(source1.get)
-            }
-          }
-
-        clumpResult(clump) mustEqual Some((List(200, 300)))
-        source1Fetches mustEqual List(Set(2), Set(20, 30))
-        source2Fetches mustEqual List(Set(3))
       }
 
       "complex scenario" in new Context {


### PR DESCRIPTION
@williamboxhall I took some time to realize that the difference between the test application and the unit test is actually the different latencies that each composition branch can have.

See https://github.com/fwbrasil/clump/commit/6f7f7dd9f887b0ba393f0dae173b619fc9a3382e, it proves that the test fails using the old execution model.

Fixes #36.