### PR TITLE
Make clumpsource interface intuitive and maplike

### DIFF
--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -5,11 +5,15 @@ import scala.collection.generic.CanBuildFrom
 
 class ClumpSource[T, U] private (val fetch: Set[T] => Future[Map[T, U]], val maxBatchSize: Int = Int.MaxValue) {
 
-  def get(inputs: T*): Clump[List[U]] = get(inputs.toList)
+  def list(inputs: T*): Clump[List[U]] = list(inputs.toList)
 
-  def get(inputs: List[T]): Clump[List[U]] = Clump.collect(inputs.map(get))
+  def list(inputs: List[T]): Clump[List[U]] = Clump.collect(inputs.map(apply))
 
-  def get(input: T): Clump[U] = new ClumpFetch(input, ClumpContext().fetcherFor(this))
+  def get(input: T): Clump[Option[U]] = apply(input).optional
+
+  def getOrElse(input: T,  default: => U): Clump[U] = apply(input).orElse(Clump.value(default))
+
+  def apply(input: T): Clump[U] = new ClumpFetch(input, ClumpContext().fetcherFor(this))
 
   def maxBatchSize(size: Int): ClumpSource[T, U] = new ClumpSource(fetch, size)
 }

--- a/src/test/scala/clump/ClumpFetcherSpec.scala
+++ b/src/test/scala/clump/ClumpFetcherSpec.scala
@@ -25,11 +25,11 @@ class ClumpFetcherSpec extends Spec {
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
 
-    val clump1 = Clump.traverse(List(1, 2))(source.get)
+    val clump1 = Clump.traverse(List(1, 2))(source.apply)
 
     clumpResult(clump1) mustEqual Some(List(10, 20))
 
-    val clump2 = Clump.traverse(List(2, 3))(source.get)
+    val clump2 = Clump.traverse(List(2, 3))(source.apply)
 
     clumpResult(clump2) mustEqual Some(List(20, 30))
 
@@ -44,7 +44,7 @@ class ClumpFetcherSpec extends Spec {
     when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
     when(repo.fetch(Set(3))).thenReturn(Future(Map(3 -> 30)))
 
-    val clump = Clump.traverse(List(1, 2, 3))(source.get)
+    val clump = Clump.traverse(List(1, 2, 3))(source.apply)
 
     clumpResult(clump) mustEqual Some(List(10, 20, 30))
 
@@ -60,8 +60,8 @@ class ClumpFetcherSpec extends Spec {
       .thenReturn(Future.exception(new IllegalStateException))
       .thenReturn(Future(Map(1 -> 10)))
 
-    clumpResult(source.get(1)) must throwA[IllegalStateException]
-    clumpResult(source.get(1)) mustEqual Some(10)
+    clumpResult(source(1)) must throwA[IllegalStateException]
+    clumpResult(source(1)) mustEqual Some(10)
 
     verify(repo, times(2)).fetch(Set(1))
     verifyNoMoreInteractions(repo)

--- a/src/test/scala/clump/ClumpSourceSpec.scala
+++ b/src/test/scala/clump/ClumpSourceSpec.scala
@@ -24,12 +24,12 @@ class ClumpSourceSpec extends Spec {
     "set input" in {
       def fetch(inputs: Set[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
       val source = Clump.sourceFrom(fetch)
-      clumpResult(source.get(1)) mustEqual Some("1")
+      clumpResult(source(1)) mustEqual Some("1")
     }
     "list input" in {
       def fetch(inputs: List[Int]) = Future.value(inputs.map(i => i -> i.toString).toMap)
       val source = Clump.sourceFrom(fetch)
-      clumpResult(source.get(1)) mustEqual Some("1")
+      clumpResult(source(1)) mustEqual Some("1")
     }
   }
 
@@ -37,19 +37,19 @@ class ClumpSourceSpec extends Spec {
     "set input" in {
       def fetch(inputs: Set[Int]) = Future.value(inputs.map(_.toString))
       val source = Clump.source(fetch)(_.toInt)
-      clumpResult(source.get(1)) mustEqual Some("1")
+      clumpResult(source(1)) mustEqual Some("1")
     }
     "seq input" in {
       def fetch(inputs: Seq[Int]) = Future.value(inputs.map(_.toString))
       val source = Clump.source(fetch)(_.toInt)
-      clumpResult(source.get(1)) mustEqual Some("1")
+      clumpResult(source(1)) mustEqual Some("1")
     }
   }
 
   "allows to create a clump source with zip as the key function (ClumpSource.zip)" in {
     def fetch(inputs: List[Int]) = Future.value(inputs.map(_.toString))
     val source = Clump.sourceZip(fetch)
-    clumpResult(source.get(1)) mustEqual Some("1")
+    clumpResult(source(1)) mustEqual Some("1")
   }
 
   "allows to create a clump source from various input/ouput type fetch functions (ClumpSource.apply)" in {
@@ -64,7 +64,7 @@ class ClumpSourceSpec extends Spec {
     def iterableToSet: Iterable[Int] => Future[List[String]] = { inputs => Future.value(inputs.map(_.toString).toList) }
     
     def testSource(source: ClumpSource[Int, String]) =
-      clumpResult(source.get(1, 2)) mustEqual Some(List("1", "2"))
+      clumpResult(source.list(1, 2)) mustEqual Some(List("1", "2"))
     
     def extractId(string: String) = string.toInt
 
@@ -86,7 +86,7 @@ class ClumpSourceSpec extends Spec {
     def iterableToMap: Iterable[Int] => Future[Map[Int, String]] = { inputs => Future.value(inputs.map(input => (input, input.toString)).toMap) }
     
     def testSource(source: ClumpSource[Int, String]) =
-      clumpResult(source.get(1, 2)) mustEqual Some(List("1", "2"))
+      clumpResult(source.list(1, 2)) mustEqual Some(List("1", "2"))
 
     testSource(ClumpSource.from(setToMap))
     testSource(ClumpSource.from(listToMap))
@@ -98,7 +98,7 @@ class ClumpSourceSpec extends Spec {
 
     when(repo.fetch(Set(1))).thenReturn(Future(Map(1 -> 2)))
 
-    clumpResult(source.get(1)) mustEqual Some(2)
+    clumpResult(source(1)) mustEqual Some(2)
 
     verify(repo).fetch(Set(1))
     verifyNoMoreInteractions(repo)
@@ -111,7 +111,7 @@ class ClumpSourceSpec extends Spec {
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
-      val clump = source.get(List(1, 2))
+      val clump = source.list(List(1, 2))
 
       clumpResult(clump) mustEqual Some(List(10, 20))
 
@@ -124,7 +124,7 @@ class ClumpSourceSpec extends Spec {
 
       when(repo.fetch(Set(1, 2))).thenReturn(Future(Map(1 -> 10, 2 -> 20)))
 
-      val clump = source.get(1, 2)
+      val clump = source.list(1, 2)
 
       clumpResult(clump) mustEqual Some(List(10, 20))
 
@@ -141,7 +141,7 @@ class ClumpSourceSpec extends Spec {
     val future =
       Future.collect {
         for (i <- 0 until 5) yield {
-          source.get(List(1)).get
+          source.list(List(1)).get
         }
       }
 

--- a/src/test/scala/clump/IntegrationSpec.scala
+++ b/src/test/scala/clump/IntegrationSpec.scala
@@ -25,8 +25,8 @@ class IntegrationSpec extends Spec {
   "A Clump should batch calls to services" in {
     val enrichedTweets = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
         for {
-          tweet <- tweets.get(tweetId)
-          user <- users.get(tweet.userId)
+          tweet <- tweets(tweetId)
+          user <- users(tweet.userId)
         } yield (tweet, user)
       }
 
@@ -40,11 +40,11 @@ class IntegrationSpec extends Spec {
     val timelineIds = List(1, 3)
     val enrichedTimelines = Clump.traverse(timelineIds) { id =>
         for {
-          timeline <- timelines.get(id)
+          timeline <- timelines(id)
           enrichedLikes <- Clump.traverse(timeline.likeIds) { id =>
             for {
-              like <- likes.get(id)
-              resources <- tracks.get(like.trackIds).join(users.get(like.userIds))
+              like <- likes(id)
+              resources <- tracks.list(like.trackIds).join(users.list(like.userIds))
             } yield (like, resources._1, resources._2)
           }
         } yield (timeline, enrichedLikes)
@@ -63,8 +63,8 @@ class IntegrationSpec extends Spec {
     val tweetIds = List(1L, 2L, 3L)
     val enrichedTweets: Clump[List[(Tweet, User)]] =
       Clump.traverse(tweetIds) { tweetId =>
-        tweets.get(tweetId).flatMap(tweet =>
-          users.get(tweet.userId).map(user => (tweet, user)))
+        tweets(tweetId).flatMap(tweet =>
+          users(tweet.userId).map(user => (tweet, user)))
       }
 
     Await.result(enrichedTweets.get) ==== Some(List(
@@ -76,8 +76,8 @@ class IntegrationSpec extends Spec {
   "it should allow unwrapping Clumped lists with clump.list" in {
     val enrichedTweets: Clump[List[(Tweet, User)]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- users.get(tweet.userId)
+        tweet <- tweets(tweetId)
+        user <- users(tweet.userId)
       } yield (tweet, user)
     }
 
@@ -90,8 +90,8 @@ class IntegrationSpec extends Spec {
   "it should work with Clump.sourceZip" in {
     val enrichedTweets = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- zippedUsers.get(tweet.userId)
+        tweet <- tweets(tweetId)
+        user <- zippedUsers(tweet.userId)
       } yield (tweet, user)
     }
 
@@ -104,8 +104,8 @@ class IntegrationSpec extends Spec {
   "A Clump can have a partial result" in {
     val onlyFullObjectGraph: Clump[List[(Tweet, User)]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- filteredUsers.get(tweet.userId)
+        tweet <- tweets(tweetId)
+        user <- filteredUsers(tweet.userId)
       } yield (tweet, user)
     }
 
@@ -113,8 +113,8 @@ class IntegrationSpec extends Spec {
 
     val partialResponses: Clump[List[(Tweet, Option[User])]] = Clump.traverse(List(1L, 2L, 3L)) { tweetId =>
       for {
-        tweet <- tweets.get(tweetId)
-        user <- filteredUsers.get(tweet.userId).optional
+        tweet <- tweets(tweetId)
+        user <- filteredUsers.get(tweet.userId)
       } yield (tweet, user)
     }
 


### PR DESCRIPTION
@fwbrasil I know you hated this last time and wanted to simplify the `ClumpSource` interface, however I wanted to float this just one last time before we're locked in to the interface and can't change it.

This is slightly different from last time and I think more intuitive. It looks and behaves exactly like the Map interface regarding the semantics of `apply`, `get` and `getOrElse`.

I brought back `list` for getting multiple items, but could be convinced to rename it back to `get` or `getAll`.

Please consider it again and if you really dislike it we can drop it :)