### PR TITLE
permit the usage of non-singleton sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,6 @@ The final result can be ```notFound``` because the user can be found or not.
 
 Sources represent the remote systems' batched interfaces. Clump offers some methods to create sources using different strategies.
 
-  **Important**: The source instances must be singletons within a Clump execution. If there are multiple instances for the same source, the batching of requests doesn't work.
-
 The ```Clump.source``` method accepts a function that may return less elements than requested. The output can also be in a different order than the inputs, since the last parameter is a function that allows Clump to determine which is the input for each output.
 
 ```scala
@@ -488,7 +486,7 @@ val usersSource = Clump.source(usersService.fetch)(_.id)
 val tracksSource = Clump.source(tracksService.fetch)(_.id)
 ```
 
-The ```ClumpSource``` instances are created using one of the shortcuts that the ```Clump``` object [provides](/src/main/scala/clump/Clump.scala#L69). They don't hold any state and allow to create Clump instances representing the [fetch](/src/main/scala/clump/ClumpSource.scala#L12). Clump uses the source instance's identity to group requests and perform batched fetches, so it is really important that each source has only one instance within a clump composition and execution.
+The ```ClumpSource``` instances are created using one of the shortcuts that the ```Clump``` object [provides](/src/main/scala/clump/Clump.scala#L69). They don't hold any state and allow to create Clump instances representing the [fetch](/src/main/scala/clump/ClumpSource.scala#L12). Clump uses the fetch function's [identity](/src/main/scala/clump/FunctionIdentity.scala) to group requests and perform batched fetches, so it is possible to have multiple instances of the same source within a clump composition and execution.
 
 ## Composition
 

--- a/src/main/scala/clump/ClumpContext.scala
+++ b/src/main/scala/clump/ClumpContext.scala
@@ -7,12 +7,12 @@ import scala.collection.mutable.HashMap
 private[clump] final class ClumpContext {
 
   private val fetchers =
-    new HashMap[ClumpSource[_, _], ClumpFetcher[_, _]]()
+    new HashMap[FunctionIdentity, ClumpFetcher[_, _]]()
 
   def fetcherFor[T, U](source: ClumpSource[T, U]) =
     synchronized {
       fetchers
-        .getOrElseUpdate(source, new ClumpFetcher(source))
+        .getOrElseUpdate(source.functionIdentity, new ClumpFetcher(source))
         .asInstanceOf[ClumpFetcher[T, U]]
     }
 

--- a/src/main/scala/clump/ClumpSource.scala
+++ b/src/main/scala/clump/ClumpSource.scala
@@ -3,31 +3,37 @@ package clump
 import com.twitter.util.Future
 import scala.collection.generic.CanBuildFrom
 
-class ClumpSource[T, U] private (val fetch: Set[T] => Future[Map[T, U]],
+class ClumpSource[T, U] private (val functionIdentity: FunctionIdentity,
+                                 val fetch: Set[T] => Future[Map[T, U]],
                                  val maxBatchSize: Int = Int.MaxValue,
                                  val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 
-  def get(inputs: T*): Clump[List[U]] = get(inputs.toList)
+  def get(inputs: T*): Clump[List[U]] = 
+    get(inputs.toList)
 
-  def get(inputs: List[T]): Clump[List[U]] = Clump.collect(inputs.map(get))
+  def get(inputs: List[T]): Clump[List[U]] = 
+    Clump.collect(inputs.map(get))
 
-  def get(input: T): Clump[U] = new ClumpFetch(input, ClumpContext().fetcherFor(this))
+  def get(input: T): Clump[U] = 
+    new ClumpFetch(input, ClumpContext().fetcherFor(this))
 
-  def maxBatchSize(size: Int): ClumpSource[T, U] = new ClumpSource(fetch, size, _maxRetries)
+  def maxBatchSize(size: Int): ClumpSource[T, U] = 
+    new ClumpSource(functionIdentity, fetch, size, _maxRetries)
 
-  def maxRetries(retries: PartialFunction[Throwable, Int]): ClumpSource[T, U] = new ClumpSource(fetch, maxBatchSize, retries)
+  def maxRetries(retries: PartialFunction[Throwable, Int]): ClumpSource[T, U] = 
+    new ClumpSource(functionIdentity, fetch, maxBatchSize, retries)
 }
 
 private[clump] object ClumpSource {
 
   def apply[T, U, C](fetch: C => Future[Iterable[U]])(keyExtractor: U => T)(implicit cbf: CanBuildFrom[Nothing, T, C]) =
-    new ClumpSource(extractKeys(adaptInput(fetch), keyExtractor))
+    new ClumpSource(FunctionIdentity(fetch), extractKeys(adaptInput(fetch), keyExtractor))
 
   def from[T, U, C](fetch: C => Future[Map[T, U]])(implicit cbf: CanBuildFrom[Nothing, T, C]) =
-    new ClumpSource(adaptInput(fetch))
+    new ClumpSource(FunctionIdentity(fetch), adaptInput(fetch))
 
   def zip[T, U](fetch: List[T] => Future[List[U]]): ClumpSource[T, U] = {
-    new ClumpSource(zipped(fetch))
+    new ClumpSource(FunctionIdentity(fetch), zipped(fetch))
   }
 
   private def zipped[T, U](fetch: List[T] => Future[List[U]]) = {

--- a/src/main/scala/clump/FunctionIdentity.scala
+++ b/src/main/scala/clump/FunctionIdentity.scala
@@ -1,0 +1,23 @@
+package clump
+
+case class FunctionIdentity private (cls: Class[_], externalParams: List[Any])
+
+object FunctionIdentity {
+  
+  // Functions don't have a common interface
+  type Function = Any
+  
+  def apply(function: Function) = {
+    val cls = function.getClass
+    new FunctionIdentity(cls, fieldValuesFor(function, cls))
+  }
+  
+  private def fieldValuesFor(function: Function, cls: Class[_]) =
+    fieldsFor(cls).map(_.get(function))
+  
+  private def fieldsFor(cls: Class[_]) = {
+    val fields = cls.getDeclaredFields
+    fields.foreach(_.setAccessible(true))
+    fields.toList
+  }
+}

--- a/src/test/scala/clump/ClumpExecutionSpec.scala
+++ b/src/test/scala/clump/ClumpExecutionSpec.scala
@@ -23,7 +23,7 @@ class ClumpExecutionSpec extends Spec {
       Future.value(inputs.map(i => i -> i * 10).toMap)
     }
 
-    val source1 = Clump.sourceFrom((i: Set[Int]) => fetchFunction(source1Fetches, i))
+    def source1 = Clump.sourceFrom((i: Set[Int]) => fetchFunction(source1Fetches, i))
     val source2 = Clump.sourceFrom((i: Set[Int]) => fetchFunction(source2Fetches, i))
   }
 

--- a/src/test/scala/clump/FunctionIdentitySpec.scala
+++ b/src/test/scala/clump/FunctionIdentitySpec.scala
@@ -1,0 +1,51 @@
+package clump
+
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class FunctionIdentitySpec extends Spec {
+
+  def function(string: String, int: Int) = ???
+
+  "detects that the same function created two times is the same" >> {
+    "without parameters from the outer scope" in {
+      def test = function _
+      FunctionIdentity(test) mustEqual FunctionIdentity(test)
+    }
+    "with parameters from the outer scope" in {
+      val string = "test"
+      def test = (int: Int) => function(string, int)
+      FunctionIdentity(test) mustEqual FunctionIdentity(test)
+    }
+  }
+
+  "detects that functions created in different places are different" >> {
+    "without parameters from the outer scope" in {
+      def test1 = function _
+      def test2 = function _
+      FunctionIdentity(test1) mustNotEqual FunctionIdentity(test2)
+    }
+    "with parameters from the outer scope" in {
+      val string = "test"
+      def test1 = (int: Int) => function(string, int)
+      def test2 = (int: Int) => function(string, int)
+      FunctionIdentity(test1) mustNotEqual FunctionIdentity(test2)
+    }
+  }
+
+  "considers the values from the outer scope to generate the identity" >> {
+    "equal" in {
+      def test(string: String) = (int: Int) => function(string, int)
+      val test1 = test("1")
+      val test2 = test("1")
+      FunctionIdentity(test1) mustEqual FunctionIdentity(test2)
+    }
+    "not equal" in {
+      def test(string: String) = (int: Int) => function(string, int)
+      val test1 = test("1")
+      val test2 = test("2")
+      FunctionIdentity(test1) mustNotEqual FunctionIdentity(test2)
+    }
+  }
+}


### PR DESCRIPTION
@williamboxhall The current limitation that forces the user to guarantee singleton sources makes harder the adoption of Clump. For instance, it is common to have a parameter with the user's authentication information. 

This pull request removes this limitation and permits the user to use Clump without worrying about the sources being singletons:

```scala
class TrackRepository(users: UserRepository) {

    private def trackSourceFor(session: Session) = Clump.source(tracksService.fetch(session, _))(_.trackId)

    def trackClump(session: Session, trackId: Long): Clump[Track] =
        for {
            track <- trackSourceFor(session).get(trackId)
            user <- users.userClump(session, track.userId)
        } yield {
            new EnrichedTrack(track, user)
        }
}
```

The ```FunctionIdentity``` class is capable to detect if the function has the same parameters from the outer scope (session) and batch the requests. It uses reflection, that isn't great solution, but there isn't an alternative afaik.

I've been using this approach for my persistence framework[0] queries for a long time without problems.

[0] http://github.com/fwbrasil/activate/