### PR TITLE
rename Clump.None to Clump.empty

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -54,7 +54,7 @@ sealed trait Clump[+T] {
 object Clump {
 
   
-  def None[T]: Clump[T] = value(scala.None)
+  def empty[T]: Clump[T] = value(scala.None)
 
   def value[T](value: T): Clump[T] = future(Future.value(Option(value)))
 

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -57,8 +57,8 @@ class ClumpApiSpec extends Spec {
       clumpResult(Clump.collect(clumps)) mustEqual Some(List(1, 2))
     }
 
-    "allows to create an empty Clump (Clump.none)" in {
-      clumpResult(Clump.None) ==== None
+    "allows to create an empty Clump (Clump.empty)" in {
+      clumpResult(Clump.empty) ==== None
     }
   }
 
@@ -155,7 +155,7 @@ class ClumpApiSpec extends Spec {
 
     "allows to defined a fallback value (clump.orElse)" >> {
       "undefined" in {
-        clumpResult(Clump.None.orElse(Clump.value(1))) ==== Some(1)
+        clumpResult(Clump.empty.orElse(Clump.value(1))) ==== Some(1)
       }
       "defined" in {
         clumpResult(Clump.value(Some(1)).orElse(Clump.value(2))) ==== Some(1)
@@ -183,7 +183,7 @@ class ClumpApiSpec extends Spec {
     }
 
     "can be made optional (clump.optional) to avoid lossy joins" in {
-      val clump: Clump[String] = Clump.None
+      val clump: Clump[String] = Clump.empty
       val optionalClump: Clump[Option[String]] = clump.optional
       clumpResult(optionalClump) ==== Some(None)
 


### PR DESCRIPTION
@williamboxhall I find ```Clump.None``` confusing, since it is different from ```Future.None```.

```scala
val clump: Clump[Track] = Clump.None
val future: Future[Option[Tack]] = Future.None
```

I think ```Clump.empty``` is a better name.