### PR TITLE
rename 'withFilter' to 'filter'

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -25,8 +25,8 @@ sealed trait Clump[+T] {
   def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRescue(this, f)
   
 
-  def withFilter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
-
+  def filter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
+  
   def orElse[B >: T](default: => Clump[B]): Clump[B] = new ClumpOrElse(this, default)
 
   def optional: Clump[Option[T]] = new ClumpOptional(this)

--- a/src/test/scala/clump/ClumpApiSpec.scala
+++ b/src/test/scala/clump/ClumpApiSpec.scala
@@ -140,9 +140,9 @@ class ClumpApiSpec extends Spec {
       }
     }
 
-    "can have its result filtered (clump.withFilter)" in {
-      clumpResult(Clump.value(1).withFilter(_ != 1)) mustEqual None
-      clumpResult(Clump.value(1).withFilter(_ == 1)) mustEqual Some(1)
+    "can have its result filtered (clump.filter)" in {
+      clumpResult(Clump.value(1).filter(_ != 1)) mustEqual None
+      clumpResult(Clump.value(1).filter(_ == 1)) mustEqual Some(1)
     }
 
     "uses a covariant type parameter" in {


### PR DESCRIPTION
@williamboxhall Another small change. The for-comprehension fallbacks to ```filter``` if ```withFilter``` is not present. I think ```filter``` is more user-friendly.

See the "About withFilter, and strictness" section here:

http://docs.scala-lang.org/tutorials/FAQ/yield.html