### PR TITLE
add the 'withFilter' method again

### DIFF
--- a/src/main/scala/clump/Clump.scala
+++ b/src/main/scala/clump/Clump.scala
@@ -19,6 +19,8 @@ sealed trait Clump[+T] {
   def handle[B >: T](f: PartialFunction[Throwable, Option[B]]): Clump[B] = new ClumpHandle(this, f)
 
   def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRescue(this, f)
+  
+  def withFilter[B >: T](f: B => Boolean): Clump[B] = filter(f)
 
   def filter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
 


### PR DESCRIPTION
@williamboxhall The compiler is generating this warning:

```
withFilter' method does not yet exist on clump.Clump[representation.Track], using filter' method instead
```