### PR TITLE
Allow sources to fail individual results in a batch fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ val usersSource = Clump.source(fetch _)(_.id)
 val userClump = usersSource.get(id)
 ```
 
+### Map with Success and Failure ###
+
+Sometimes sources can mark individual entries as failed, even though the entire fetch function succeeded. For these sources, a function can be provided that maps from id to a Try object that can be marked as either Success or Failure.
+
+```scala
+def fetch(ids: List[Int]): Future[Map[Int, Try[User]]] = ...
+
+val usersSource = Clump.source(fetch _)
+
+val userClump = usersClump.get(id)
+```
+
+The userClump will be either contain a User if the value for that id was Success(User), otherwise it will contain the exception in the Failure object for that id. As usual, if the id is not found in the map then the Clump will be undefined.
+
 ### List with zip function ###
 
 The ```Clump.sourceZip``` methods accepts a function that produces a list of outputs for each provided input. The result must keep the same order as the inputs list.

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -3,7 +3,7 @@ package io.getclump
 import scala.collection.generic.CanBuildFrom
 
 
-class ClumpSource[T, U] private[getclump] (val fetch: List[T] => Future[Map[T, U]],
+class ClumpSource[T, U] private[getclump] (val fetch: List[T] => Future[Map[T, Try[U]]],
                                            val maxBatchSize: Int = 100,
                                            val _maxRetries: PartialFunction[Throwable, Int] = PartialFunction.empty) {
 

--- a/src/main/scala/io/getclump/Sources.scala
+++ b/src/main/scala/io/getclump/Sources.scala
@@ -78,7 +78,9 @@ protected[getclump] trait Sources extends Tuples {
     new ClumpSource(parameterizeFetch(normalize4, denormalize4[A, B, C, D, K], fetch4(fetch)))
 
   /**
-   * TODO
+   * Create a clump source from a function that accepts inputs and returns a future map from input to resulting value or failure.
+   * The `Try` in the value of the map allows marking of individual entries as failed. In regular [[source]] creation only the
+   * entire request's future can be marked as failed.
    */
   def sourceTry[KS, K, V](fetch: KS => Future[Map[K, Try[V]]])
                          (implicit cbf: CanBuildFrom[Nothing, K, KS], ec: ExecutionContext): ClumpSource[K, V] =

--- a/src/main/scala/io/getclump/Tuples.scala
+++ b/src/main/scala/io/getclump/Tuples.scala
@@ -1,8 +1,5 @@
 package io.getclump
 
-import scala.concurrent.ExecutionContext
-
-
 protected[getclump] trait Tuples {
   protected[getclump] def normalize1[A, B] = (inputs: (A, B)) => inputs match {
     case (a, b) => ((a), b)
@@ -36,34 +33,19 @@ protected[getclump] trait Tuples {
     case ((a, b, c, d), e) => (a, b, c, d, e)
   }
 
-  protected[getclump] def fetch1[A, B, C](fetch: (A, B) => Future[Iterable[C]]) = (params: (A), values: B) => (params, values) match {
+  protected[getclump] def fetch1[A, B, C](fetch: (A, B) => Future[C]) = (params: (A), values: B) => (params, values) match {
     case ((a), b) => fetch(a, b)
   }
 
-  protected[getclump] def fetch2[A, B, C, D](fetch: (A, B, C) => Future[Iterable[D]]) = (params: (A, B), values: C) => (params, values) match {
+  protected[getclump] def fetch2[A, B, C, D](fetch: (A, B, C) => Future[D]) = (params: (A, B), values: C) => (params, values) match {
     case ((a, b), c) => fetch(a, b, c)
   }
 
-  protected[getclump] def fetch3[A, B, C, D, E](fetch: (A, B, C, D) => Future[Iterable[E]]) = (params: (A, B, C), values: D) => (params, values) match {
+  protected[getclump] def fetch3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E]) = (params: (A, B, C), values: D) => (params, values) match {
     case ((a, b, c), d) => fetch(a, b, c, d)
   }
 
-  protected[getclump] def fetch4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[Iterable[F]]) = (params: (A, B, C, D), values: E) => (params, values) match {
+  protected[getclump] def fetch4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F]) = (params: (A, B, C, D), values: E) => (params, values) match {
     case ((a, b, c, d), e) => fetch(a, b, c, d, e)
   }
-
-  protected[getclump] def adapt[A, B](fetch: A => Future[B])(implicit ec: ExecutionContext) = (keys: Iterable[A]) =>
-    Future.sequence(keys.toSeq.map(key => fetch(key).map(value => key -> value))).map(_.toMap)
-
-  protected[getclump] def adapt1[A, B, C](fetch: (A, B) => Future[C])(implicit ec: ExecutionContext) = (a: A, keys: Iterable[B]) =>
-    Future.sequence(keys.toSeq.map(key => fetch(a, key).map(value => key -> value))).map(_.toMap)
-
-  protected[getclump] def adapt2[A, B, C, D](fetch: (A, B, C) => Future[D])(implicit ec: ExecutionContext) = (a: A, b: B, keys: Iterable[C]) =>
-    Future.sequence(keys.toSeq.map(key => fetch(a, b, key).map(value => key -> value))).map(_.toMap)
-
-  protected[getclump] def adapt3[A, B, C, D, E](fetch: (A, B, C, D) => Future[E])(implicit ec: ExecutionContext) = (a: A, b: B, c: C, keys: Iterable[D]) =>
-    Future.sequence(keys.toSeq.map(key => fetch(a, b, c, key).map(value => key -> value))).map(_.toMap)
-
-  protected[getclump] def adapt4[A, B, C, D, E, F](fetch: (A, B, C, D, E) => Future[F])(implicit ec: ExecutionContext) = (a: A, b: B, c: C, d: D, keys: Iterable[E]) =>
-    Future.sequence(keys.toSeq.map(key => fetch(a, b, c, d, key).map(value => key -> value))).map(_.toMap)
 }

--- a/src/main/scala/io/getclump/package-twitter.scala.tmpl
+++ b/src/main/scala/io/getclump/package-twitter.scala.tmpl
@@ -5,6 +5,11 @@ package object getclump {
   // Execution contexts are not used by twitter-util so this allows you not to have to specify it
   private[getclump] implicit val ec = scala.concurrent.ExecutionContext.global
 
+  private[getclump]type Try[+T] = com.twitter.util.Try[T]
+  private[getclump] val Try = com.twitter.util.Try
+  private[getclump] val Success = com.twitter.util.Return
+  private[getclump] val Failure = com.twitter.util.Throw
+
   private[getclump]type Promise[T] = com.twitter.util.Promise[T]
   private[getclump] val Promise = com.twitter.util.Promise
 

--- a/src/main/scala/io/getclump/package.scala
+++ b/src/main/scala/io/getclump/package.scala
@@ -2,6 +2,11 @@ package io
 
 package object getclump {
 
+  private[getclump]type Try[+T] = scala.util.Try[T]
+  private[getclump] val Try = scala.util.Try
+  private[getclump] val Success = scala.util.Success
+  private[getclump] val Failure = scala.util.Failure
+
   private[getclump]type Promise[T] = scala.concurrent.Promise[T]
   private[getclump] val Promise = scala.concurrent.Promise
 

--- a/src/test/scala/io/getclump/SourcesSpec.scala
+++ b/src/test/scala/io/getclump/SourcesSpec.scala
@@ -154,7 +154,7 @@ class SourcesSpec extends Spec {
     }
   }
 
-  "creates a clump source from various input/ouput type fetch functions (ClumpSource.apply)" in {
+  "creates a clump source from various input/ouput type fetch functions" in {
     def setToSet: Set[Int] => Future[Set[String]] = { inputs => Future.successful(inputs.map(_.toString)) }
     def listToList: List[Int] => Future[List[String]] = { inputs => Future.successful(inputs.map(_.toString)) }
     def iterableToIterable: Iterable[Int] => Future[Iterable[String]] = { inputs => Future.successful(inputs.map(_.toString)) }
@@ -181,7 +181,7 @@ class SourcesSpec extends Spec {
     testSource(Clump.source(iterableToSet)(extractId))
   }
 
-  "creates a clump source from various input/ouput type fetch functions (ClumpSource.from)" in {
+  "creates a clump source from various input/ouput type fetch functions" in {
 
     def setToMap: Set[Int] => Future[Map[Int, String]] = { inputs => Future.successful(inputs.map(input => (input, input.toString)).toMap) }
     def listToMap: List[Int] => Future[Map[Int, String]] = { inputs => Future.successful(inputs.map(input => (input, input.toString)).toMap) }

--- a/src/test/scala/io/getclump/SourcesSpec.scala
+++ b/src/test/scala/io/getclump/SourcesSpec.scala
@@ -90,6 +90,41 @@ class SourcesSpec extends Spec {
     }
   }
 
+  "creates a clump source that allows marking individual entries as failed" >> {
+    "list input" in {
+      def fetch(inputs: List[Int]) = Future.successful(inputs.map(x => x -> Try(1 / x)).toMap)
+      val source = Clump.sourceTry(fetch _)
+      clumpResult(source.get(1)) mustEqual Some(1)
+      clumpResult(source.get(0)) must throwA[ArithmeticException]
+    }
+    "extra params" >> {
+      "one" in {
+        def fetch(param1: Int, inputs: List[Int]) = Future.successful(inputs.map(x => x -> Try(1 / (x + param1))).toMap)
+        val source = Clump.sourceTry(fetch _)
+        clumpResult(source.get(1, 0)) mustEqual Some(1)
+        clumpResult(source.get(1, -1)) must throwA[ArithmeticException]
+      }
+      "two" in {
+        def fetch(param1: Int, param2: Int, inputs: List[Int]) = Future.successful(inputs.map(x => x -> Try(1 / (x + param1 + param2))).toMap)
+        val source = Clump.sourceTry(fetch _)
+        clumpResult(source.get(1, 0, 0)) mustEqual Some(1)
+        clumpResult(source.get(1, 1, -2)) must throwA[ArithmeticException]
+      }
+      "three" in {
+        def fetch(param1: Int, param2: Int, param3: Int, inputs: List[Int]) = Future.successful(inputs.map(x => x -> Try(1 / (x + param1 + param2 + param3))).toMap)
+        val source = Clump.sourceTry(fetch _)
+        clumpResult(source.get(1, 0, 0, 0)) mustEqual Some(1)
+        clumpResult(source.get(1, 1, 1, -3)) must throwA[ArithmeticException]
+      }
+      "four" in {
+        def fetch(param1: Int, param2: Int, param3: Int, param4: Int, inputs: List[Int]) = Future.successful(inputs.map(x => x -> Try(1 / (x + param1 + param2 + param3 + param4))).toMap)
+        val source = Clump.sourceTry(fetch _)
+        clumpResult(source.get(1, 0, 0, 0, 0)) mustEqual Some(1)
+        clumpResult(source.get(1, 1, 1, 1, -4)) must throwA[ArithmeticException]
+      }
+    }
+  }
+
   "creates a clump source with zip as the key function" >> {
     "list input" in {
       def fetch(inputs: List[Int]) = Future.successful(inputs.map(_.toString))
@@ -126,9 +161,17 @@ class SourcesSpec extends Spec {
 
       val source = Clump.sourceSingle(fetch _)
 
-      clumpResult(source.get(1)) ==== Some(Set(1, 2, 3))
-      clumpResult(source.get(2)) ==== Some(Set(2, 3, 4))
-      clumpResult(source.get(List(1, 2))) ==== Some(List(Set(1, 2, 3), Set(2, 3, 4)))
+      clumpResult(source.get(1)) mustEqual Some(Set(1, 2, 3))
+      clumpResult(source.get(2)) mustEqual Some(Set(2, 3, 4))
+      clumpResult(source.get(List(1, 2))) mustEqual Some(List(Set(1, 2, 3), Set(2, 3, 4)))
+    }
+    "function with failure" in {
+      def fetch(input: Int) = if (input % 2 == 0) Future.successful(input / 2) else Future.failed(new ArithmeticException)
+
+      val source = Clump.sourceSingle(fetch _)
+
+      clumpResult(source.get(2)) mustEqual Some(1)
+      clumpResult(source.get(1)) must throwA[ArithmeticException]
     }
     "extra params" >> {
       "one" in {


### PR DESCRIPTION
Some RPC systems (like rest.li used at LinkedIn) allow a batch response to contain both successful and failed entries. For example, if I fetch the profiles for ids 1 and 2, it's possible that 1 could return a profile and 2 will return an UnauthorizedAccess. Visualized:

``` scala
Map(
  1 -> Entity(Profile),
  2 -> Error(UnauthorizedAccess)
)
```

Currently I have only two choices to deal with this:
1. Remove all error entries from the Map. But then you lose all the error information which makes it difficult to debug why things are missing.
2. If I need access to the error, I can fail the entire fetch, but then you lose the profiles that were successfully returned.

This change fixes that by introducing the ability to explicitly define a Try in the resulting map. If the Try is a Failure, then that Clump will be failed. Otherwise it will behave as normal.

Added a `.sourceTry` method to create these types of sources. Everything else stays the same. Now if you use `.sourceTry` then the example above changes to the expected behaviour:
`profileSource.get(1)` will return a Clump containing the Profile.
`profileSource.get(2)` fails the Clump with an UnauthorizedAccess exception.

A good side effect of this is that `.sourceSingle` now handles exceptions much better as well. If one call to the single source throws an exception it only fails that Clump instead of failing everything in that "batch" fetch. I also took some time to refactor the single source creation into a parameterize method following the pattern of the other types of sources.
