### PR TITLE
Proposal: Add ClumpNoSuchElementException and simplify Clump API

### DIFF
--- a/src/main/scala/io/getclump/Clump.scala
+++ b/src/main/scala/io/getclump/Clump.scala
@@ -64,35 +64,31 @@ sealed trait Clump[+T] {
    */
   def join[U](other: Clump[U]): Clump[(T, U)] = new ClumpJoin(this, other)
 
+  @deprecated("Use recover instead", "1.2")
+  def handle[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = recover(f)
+
   /**
    * Define a fallback value to use in the case of specified exceptions
    */
-  def handle[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = new ClumpHandle(this, f)
+  def recover[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = new ClumpRecover(this, f)
 
-  /**
-   * Alias for [[handle]]
-   */
-  def recover[B >: T](f: PartialFunction[Throwable, B]): Clump[B] = handle(f)
+  @deprecated("Use recoverWith instead", "1.2")
+  def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = recoverWith(f)
 
   /**
    * Define a fallback clump to use in the case of specified exceptions
    */
-  def rescue[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRescue(this, f)
-
-  /**
-   * Alias for [[rescue]]
-   */
-  def recoverWith[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = rescue(f)
+  def recoverWith[B >: T](f: PartialFunction[Throwable, Clump[B]]): Clump[B] = new ClumpRecoverWith(this, f)
 
   /**
    * On any exception, fallback to a default value
    */
-  def fallback[B >: T](default: => B): Clump[B] = handle(PartialFunction(_ => default))
+  def fallback[B >: T](default: => B): Clump[B] = recover(PartialFunction(_ => default))
 
   /**
    * On any exception, fallback to a default clump
    */
-  def fallbackTo[B >: T](default: => Clump[B]): Clump[B] = rescue(PartialFunction(_ => default))
+  def fallbackTo[B >: T](default: => Clump[B]): Clump[B] = recoverWith(PartialFunction(_ => default))
 
   /**
    * Alias for [[filter]] used by for-comprehensions
@@ -102,17 +98,16 @@ sealed trait Clump[+T] {
   /**
    * Apply a filter to this clump so that the result will only be defined if the predicate function returns true
    */
-  def filter[B >: T](f: B => Boolean): Clump[B] = new ClumpFilter(this, f)
+  def filter[B >: T](f: B => Boolean): Clump[B] =
+    map { r => if (f(r)) r else throw ClumpNoSuchElementException("Clump.filter predicate is not satisfied") }
 
-  /**
-   * If this clump does not return a value then use the default instead
-   */
-  def orDefault[B >: T](default: => B): Clump[B] = new ClumpOrElse(this, Clump.value(default))
+  @deprecated("Use .optional.map(_.getOrElse(default)) instead", "1.2")
+  def orDefault[B >: T](default: => B): Clump[B] =
+    optional.map(_.getOrElse(default))
 
-  /**
-   * If this clump does not return a value then use the value from a default clump instead
-   */
-  def orElse[B >: T](default: => Clump[B]): Clump[B] = new ClumpOrElse(this, default)
+  @deprecated("Use .optional.flatMap(_.map(Clump.successful).getOrElse(default)) instead", "1.2")
+  def orElse[B >: T](default: => Clump[B]): Clump[B] =
+    optional.flatMap(_.map(Clump.successful).getOrElse(default))
 
   /**
    * Mark a clump as optional so that its underlying value is an option to avoid lossy joins
@@ -121,35 +116,25 @@ sealed trait Clump[+T] {
 
   /**
    * A utility method for automatically unwrapping the underlying value
-   * @throws NoSuchElementException if the underlying value is not defined
+   * @throws ClumpNoSuchElementException if the underlying value is not defined
    */
-  def apply()(implicit ec: ExecutionContext): Future[T] = get.map(_.getOrElse { throw new NoSuchElementException("Clump result was not defined") })
+  def apply()(implicit ec: ExecutionContext): Future[T] =
+    new ClumpContext().flush(List(this)).flatMap { _ => result }
 
-  /**
-   * Get the result of the clump or provide a fallback value in the case where the result is not defined
-   */
-  def getOrElse[B >: T](default: => B)(implicit ec: ExecutionContext): Future[B] = get.map(_.getOrElse(default))
+  @deprecated("Use .optional.apply().map(_.getOrElse(default)) instead", "1.2")
+  def getOrElse[B >: T](default: => B)(implicit ec: ExecutionContext): Future[B] =
+    optional.apply().map(_.getOrElse(default))
 
-  /**
-   * If the underlying value is a list, then this will return Nil instead of None when the result is not defined
-   */
+  @deprecated("Use .optional.apply().map(_.getOrElse(Nil)) instead", "1.2")
   def list[B >: T](implicit cbf: CanBuildFrom[Nothing, Nothing, B], ec: ExecutionContext): Future[B] =
-    get.map(_.getOrElse(cbf().result()))
+    optional.apply().map(_.getOrElse(cbf().result()))
 
-  /**
-   * Trigger execution of a clump. The result will not be defined if any of the clump sources returned less elements
-   * than requested.
-   */
-  def get(implicit ec: ExecutionContext): Future[Option[T]] =
-    new ClumpContext()
-      .flush(List(this))
-      .flatMap { _ =>
-        result
-      }
+  @deprecated("Use .optional.apply() instead", "1.2")
+  def get(implicit ec: ExecutionContext): Future[Option[T]] = optional.apply()
 
   protected[getclump] def upstream: List[Clump[_]] = List.empty[Clump[_]]
   protected[getclump] def downstream(implicit ec: ExecutionContext): Future[Option[Clump[_]]] = Future.successful(None)
-  protected[getclump] def result(implicit ec: ExecutionContext): Future[Option[T]]
+  protected[getclump] def result(implicit ec: ExecutionContext): Future[T]
 }
 
 /**
@@ -160,96 +145,70 @@ object Clump extends Joins with Sources {
   /**
    * Create an empty clump
    */
-  def empty[T]: Clump[T] = new ClumpEmpty()
+  def empty[T]: Clump[T] = failed(ClumpNoSuchElementException("Clump.empty"))
 
-  /**
-   * Alias for [[value]] except that it propagates exceptions inside a clump instance
-   */
-  def apply[T](value: => T): Clump[T] = try { this.value(value) } catch { case NonFatal(e) => this.exception(e) }
+  @deprecated("Use Clump.successful or Clump.failed instead", "1.2")
+  def apply[T](value: => T): Clump[T] = try { successful(value) } catch { case NonFatal(e) => failed(e) }
+
+  @deprecated("Use Clump.successful instead", "1.2")
+  def value[T](value: T): Clump[T] = successful(value)
 
   /**
    * The unit method: create a clump whose value has already been resolved to the input
    */
-  def value[T](value: T): Clump[T] = future(Future.successful(value))
+  def successful[T](value: T): Clump[T] = future(Future.successful(value))
 
-  /**
-   * Alias for [[value]]
-   */
-  def successful[T](value: T): Clump[T] = this.value(value)
+  @deprecated("Use Clump.failed instead", "1.2")
+  def exception[T](exception: Throwable): Clump[T] = failed(exception)
 
   /**
    * Create a failed clump with the given exception
    */
-  def exception[T](exception: Throwable): Clump[T] = future(Future.failed(exception))
-
-  /**
-   * Alias for [[exception]]
-   */
-  def failed[T](exception: Throwable): Clump[T] = this.exception(exception)
+  def failed[T](exception: Throwable): Clump[T] = future(Future.failed(exception))
 
   /**
    * Create a clump whose value will be the result of the inputted future
    */
   def future[T](future: Future[T]): Clump[T] = new ClumpFuture(future)
 
-  /**
-   * Transform a number of values into a single clump by first applying a function.
-   *
-   * Equivalent to:
-   * {{{
-   *   Clump.collect(clump1.map(f), clump2.map(f))
-   * }}}
-   */
+  @deprecated("Use Future.traverse(List()) instead", "1.2")
   def traverse[T, U](inputs: T*)(f: T => Clump[U]): Clump[List[U]] = traverse(inputs.toList)(f)
 
-  /**
-   * Transform a number of clump instances into a single clump
-   */
-  def collect[T](clumps: Clump[T]*): Clump[List[T]] = collect(clumps.toList)
+  @deprecated("Use Future.sequence(List()) instead", "1.2")
+  def collect[T](clumps: Clump[T]*): Clump[List[T]] = sequence(clumps.toList)
 
-  /**
-   * Alias for [[collect]]
-   */
-  def sequence[T](clumps: Clump[T]*): Clump[List[T]] = collect(clumps: _*)
+  @deprecated("Use Future.sequence(List()) instead", "1.2")
+  def sequence[T](clumps: Clump[T]*): Clump[List[T]] = sequence(clumps.toList)
 
   /**
    * Transform a collection of clump instances into a single clump by first applying a function.
    *
    * Equivalent to:
    * {{{
-   *   Clump.collect(list.map(f))
+   *   Clump.sequence(list.map(f))
    * }}}
    */
   def traverse[T, U, C[_] <: Iterable[_]](inputs: C[T])(f: T => Clump[U])(implicit cbf: CanBuildFrom[C[T], U, C[U]]): Clump[C[U]] =
-    collect(inputs.toList.asInstanceOf[List[T]].map(f)).map(cbf.apply(inputs).++=(_).result())
+    sequence(inputs.toList.asInstanceOf[List[T]].map(f)).map(cbf.apply(inputs).++=(_).result())
+
+  @deprecated("Use Clump.sequence instead", "1.2")
+  def collect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]): Clump[C[T]] =
+    sequence(clumps)
 
   /**
    * Transform a collection of clump instances into a single clump
    */
-  def collect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]): Clump[C[T]] =
-    new ClumpCollect(clumps)
-
-  /**
-   * Alias for [[collect]]
-   */
   def sequence[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]): Clump[C[T]] =
-    collect(clumps)
+    new ClumpSequence(clumps)
 
-}
-
-private[getclump] class ClumpEmpty extends Clump[Nothing] {
-  override protected[getclump] def result(implicit ec: ExecutionContext) = Future.successful(None)
 }
 
 private[getclump] class ClumpFuture[T](future: Future[T]) extends Clump[T] {
-  override protected[getclump] def downstream(implicit ec: ExecutionContext) = future.map(_ => None).recover {
-    case _ => None
-  }
-  override protected[getclump] def result(implicit ec: ExecutionContext) = future.map(Some(_))
+  override protected[getclump] def result(implicit ec: ExecutionContext) = future
 }
 
 private[getclump] class ClumpFetch[T, U](input: T, val source: ClumpSource[T, U]) extends Clump[U] {
-  private[this] val promise = Promise[Option[U]]
+  private[this] val promise = Promise[U]
 
   protected[getclump] def attachTo(fetcher: ClumpFetcher[T, U])(implicit ec: ExecutionContext) =
     fetcher.get(input).onComplete(promise.complete)
@@ -261,87 +220,74 @@ private[getclump] class ClumpJoin[A, B](a: Clump[A], b: Clump[B]) extends Clump[
   override protected[getclump] val upstream = List(a, b)
   override protected[getclump] def result(implicit ec: ExecutionContext) =
     a.result.zip(b.result)
-      .map {
-        case (Some(valueA), Some(valueB)) => Some((valueA, valueB))
-        case _                            => None
-      }
 }
 
-private[getclump] class ClumpCollect[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]) extends Clump[C[T]] {
+private[getclump] class ClumpSequence[T, C[_] <: Iterable[_]](clumps: C[Clump[T]])(implicit cbf: CanBuildFrom[C[Clump[T]], T, C[T]]) extends Clump[C[T]] {
   override protected[getclump] val upstream =
     clumps.toList.asInstanceOf[List[Clump[T]]]
   override protected[getclump] def result(implicit ec: ExecutionContext) =
     Future
-      .sequence(upstream.map(_.result))
+      .sequence(upstream.map(_.result.map(Some(_)).recover {
+        // TODO: Remove in version 2.0
+        case _: ClumpNoSuchElementException => None
+      }))
       .map(_.flatten)
       .map(cbf.apply(clumps).++=(_).result())
-      .map(Some(_))
 }
 
 private[getclump] class ClumpMap[T, U](clump: Clump[T], f: T => U) extends Clump[U] {
   override protected[getclump] val upstream = List(clump)
   override protected[getclump] def result(implicit ec: ExecutionContext) =
-    clump.result.map(_.map(f))
+    clump.result.map(f)
 }
 
 private[getclump] class ClumpFlatMap[T, U](clump: Clump[T], f: T => Clump[U]) extends Clump[U] {
-  private[this] val promise = Promise[Option[Clump[U]]]()
+  private[this] val promise = Promise[Clump[U]]()
   private[this] def partial(implicit ec: ExecutionContext) =
-    clump.result.map(_.map(f))
+    clump.result.map(f)
 
   override protected[getclump] val upstream = List(clump)
   override protected[getclump] def downstream(implicit ec: ExecutionContext) =
-    promise.tryCompleteWith(partial).future
-  override protected[getclump] def result(implicit ec: ExecutionContext) =
-    promise.future.flatMap {
-      case Some(newClump) => newClump.result
-      case None           => Future.successful(None)
+    promise.tryCompleteWith(partial).future.map(Some(_)).recover {
+      case _: ClumpNoSuchElementException => None
     }
-}
-
-private[getclump] class ClumpHandle[T](clump: Clump[T], f: PartialFunction[Throwable, T]) extends Clump[T] {
-  override protected[getclump] val upstream = List(clump)
-  override protected[getclump] def result(implicit ec: ExecutionContext) =
-    clump.result.recover(f.andThen(Some(_)))
-}
-
-private[getclump] class ClumpRescue[T](clump: Clump[T], rescue: PartialFunction[Throwable, Clump[T]]) extends Clump[T] {
-  private[this] val promise = Promise[Clump[T]]
-  private[this] def partial(implicit ec: ExecutionContext) =
-    clump.result.map(_.map(Clump.value).getOrElse(Clump.empty)).recover {
-      case exception if rescue.isDefinedAt(exception) => rescue(exception)
-      case exception                                  => Clump.exception(exception)
-    }
-
-  override protected[getclump] val upstream = List(clump)
-  override protected[getclump] def downstream(implicit ec: ExecutionContext) =
-    promise.tryCompleteWith(partial).future.map(Some(_))
   override protected[getclump] def result(implicit ec: ExecutionContext) =
     promise.future.flatMap(_.result)
 }
 
-private[getclump] class ClumpFilter[T](clump: Clump[T], f: T => Boolean) extends Clump[T] {
+private[getclump] class ClumpRecover[T](clump: Clump[T], f: PartialFunction[Throwable, T]) extends Clump[T] {
   override protected[getclump] val upstream = List(clump)
   override protected[getclump] def result(implicit ec: ExecutionContext) =
-    clump.result.map(_.filter(f))
+    clump.result.recover {
+      // TODO: Remove in version 2.0
+      case exception if f.isDefinedAt(exception) && !exception.isInstanceOf[ClumpNoSuchElementException] => f(exception)
+    }
 }
 
-private[getclump] class ClumpOrElse[T](clump: Clump[T], default: => Clump[T]) extends Clump[T] {
+private[getclump] class ClumpRecoverWith[T](clump: Clump[T], f: PartialFunction[Throwable, Clump[T]]) extends Clump[T] {
   private[this] val promise = Promise[Clump[T]]
   private[this] def partial(implicit ec: ExecutionContext) =
-    clump.result.map {
-      case Some(value) => Clump.value(value)
-      case None        => default
+    clump.result.map(Clump.successful).recover {
+      // TODO: Remove in version 2.0
+      case exception: ClumpNoSuchElementException => Clump.failed(exception)
+      case exception if f.isDefinedAt(exception)  => f(exception)
+      case exception                              => Clump.failed(exception)
     }
 
   override protected[getclump] val upstream = List(clump)
   override protected[getclump] def downstream(implicit ec: ExecutionContext) =
-    promise.tryCompleteWith(partial).future.map(Some(_))
+    promise.tryCompleteWith(partial).future.map(Some(_)).recover {
+      case _: ClumpNoSuchElementException => None
+    }
   override protected[getclump] def result(implicit ec: ExecutionContext) =
     promise.future.flatMap(_.result)
 }
 
+// TODO: Once the matchers in recover / recoverWith for ClumpNoSuchElementException are removed this can be inlined
 private[getclump] class ClumpOptional[T](clump: Clump[T]) extends Clump[Option[T]] {
   override protected[getclump] val upstream = List(clump)
-  override protected[getclump] def result(implicit ec: ExecutionContext) = clump.result.map(Some(_))
+  override protected[getclump] def result(implicit ec: ExecutionContext) =
+    clump.result.map(Some(_)).recover {
+      case _: ClumpNoSuchElementException => None
+    }
 }

--- a/src/main/scala/io/getclump/ClumpNoSuchElementException.scala
+++ b/src/main/scala/io/getclump/ClumpNoSuchElementException.scala
@@ -1,0 +1,3 @@
+package io.getclump
+
+case class ClumpNoSuchElementException(message: String) extends NoSuchElementException(message)

--- a/src/main/scala/io/getclump/ClumpSource.scala
+++ b/src/main/scala/io/getclump/ClumpSource.scala
@@ -26,7 +26,7 @@ class ClumpSource[T, U] private[getclump] (val fetch: List[T] => Future[Map[T, T
    */
   def get[C[_] <: Iterable[_]](inputs: C[T])(implicit cbf: CanBuildFrom[Nothing, U, C[U]]): Clump[C[U]] = {
     val listInputs = inputs.toList.asInstanceOf[List[T]]
-    val clumpList = Clump.collect(listInputs.map(get))
+    val clumpList = Clump.sequence(listInputs.map(get))
     clumpList.map(list => cbf.apply().++=(list).result())
   }
 


### PR DESCRIPTION
Currently a lot of confusion at work comes from the fact that Clumps can be in one of 3 states:
State 1: Successful - contains the expected element
State 2: Failed - contains an exception
State 3: Undefined - key was missing from batch get, contains neither element nor exception

This commit unifies states 2 and 3 into a single "Failed" state by introducing ClumpNoSuchElementException which gets thrown when a key is missing from a batch get.

Currently, this only changes the internal implementation and not the public API. (It greatly simplifies the internal implementation because Clumps don't store Options anymore). In the future, I would like to expose ClumpNoSuchElementException and allow it to be the main way of dealing with missing keys.

The two main goals I have with this commit are:
- reduce the number of possible states a Clump can be in
- simplify the API by removing extraneous/confusing methods

To accomplish these goals, I've deprecated the following things so that they can be removed in version 2.0:

Methods that only dealt with state 3:
- `orElse`
- `orDefault`
- `getOrElse`
- `list`
- `get`

With the ClumpNoSuchElementException exposed these methods could all be implemented in user code instead of special subclasses of Clump.

Methods that are synonyms for other methods:
- `handle`
- `rescue`
- `Clump.apply`
- `Clump.value`
- `Clump.exception`
- `Clump.traverse` and `Clump.collect` and `Clump.sequence` that had parameters lists
- `Clump.collect`

The following behaviour changes will be introduced in version 2.0:
- Clump.sequence will no longer filter out undefined clumps. Instead, mark each Clump as optional and then flatten the resulting list
- recover and recoverWith will allow you to match on ClumpNoSuchElementException
- fallback and fallbackTo will catch ClumpNoSuchElementExceptions

Somewhat unrelated, I would also like to rename `Clump.future` to `Clump.apply` because it gets used so often, but the current `apply` method has to be deprecated first.

This commit will turn into version 1.2, which follows versioning rules because no behaviour is changing. The only other change is that `.apply` now throws a ClumpNoSuchElementException, but this is a subclass on NoSuchElementException so it's backwards compatible.
